### PR TITLE
test: complete the test for transient outputs

### DIFF
--- a/substratest/client.py
+++ b/substratest/client.py
@@ -1,5 +1,6 @@
 import tempfile
 import time
+import typing
 from typing import Optional
 
 import requests
@@ -188,7 +189,7 @@ class Client:
             with open(path, "rb") as f:
                 return f.read()
 
-    def get_task_models(self, compute_task_key: str) -> list[substra.models.OutModel]:
+    def get_task_models(self, compute_task_key: str) -> typing.List[substra.models.OutModel]:
         return self._client.list_model(filters={"compute_task_key": [compute_task_key]})
 
     def get_logs(self, tuple_key):

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -188,6 +188,9 @@ class Client:
             with open(path, "rb") as f:
                 return f.read()
 
+    def get_task_models(self, compute_task_key: str) -> list[substra.models.OutModel]:
+        return self._client.list_model(filters={"compute_task_key": [compute_task_key]})
+
     def get_logs(self, tuple_key):
         return self._client.get_logs(tuple_key)
 

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -6,7 +6,8 @@ from substra.sdk import models
 
 import substratest as sbt
 from substratest.client import Client
-from substratest.factory import AlgoCategory, AssetsFactory
+from substratest.factory import AlgoCategory
+from substratest.factory import AssetsFactory
 from substratest.fl_interface import FL_ALGO_PREDICT_COMPOSITE
 from substratest.fl_interface import FLTaskInputGenerator
 from substratest.fl_interface import FLTaskOutputGenerator

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -5,7 +5,8 @@ import substra
 from substra.sdk import models
 
 import substratest as sbt
-from substratest.factory import AlgoCategory
+from substratest.client import Client
+from substratest.factory import AlgoCategory, AssetsFactory
 from substratest.fl_interface import FL_ALGO_PREDICT_COMPOSITE
 from substratest.fl_interface import FLTaskInputGenerator
 from substratest.fl_interface import FLTaskOutputGenerator
@@ -757,11 +758,11 @@ def test_compute_plan_no_batching(factory, client, default_dataset):
 
 @pytest.mark.slow
 @pytest.mark.remote_only
-def test_compute_plan_transient_outputs(factory, client, default_dataset):
+def test_compute_plan_transient_outputs(factory: AssetsFactory, client: Client, default_dataset):
     """
     Create a simple compute plan with tasks using transient inputs, check if the flag is set
     """
-    data_sample_1_input, _, _, _ = default_dataset.train_data_sample_inputs
+    data_sample_1_input, data_sample_2_input, _, _ = default_dataset.train_data_sample_inputs
 
     # Register the Algo
     simple_algo_spec = factory.create_algo(AlgoCategory.simple)
@@ -774,12 +775,35 @@ def test_compute_plan_transient_outputs(factory, client, default_dataset):
         outputs=FLTaskOutputGenerator.traintuple(transient=True),
     )
 
+    cp_spec.create_traintuple(
+        algo=simple_algo,
+        inputs=default_dataset.opener_input
+        + [data_sample_2_input]
+        + FLTaskInputGenerator.trains_to_train([traintuple_spec_1.traintuple_id]),
+    )
+
     cp_added = client.add_compute_plan(cp_spec)
     client.wait(cp_added)
 
     traintuple_1 = client.get_traintuple(traintuple_spec_1.traintuple_id)
-
     assert traintuple_1.outputs[OutputIdentifiers.model].is_transient is True
+
+    # Validate that the transient model is properly deleted
+    model = client.get_task_models(traintuple_spec_1.traintuple_id)[0]
+    client.wait_model_deletion(model.key)
+
+    # Validate that we can't create a new task that use this model
+    traintuple_spec_3 = factory.create_traintuple(
+        algo=simple_algo,
+        inputs=default_dataset.opener_input
+        + [data_sample_2_input]
+        + FLTaskInputGenerator.trains_to_train([traintuple_spec_1.traintuple_id]),
+    )
+
+    with pytest.raises(substra.exceptions.InvalidRequest) as err:
+        client.add_traintuple(traintuple_spec_3)
+
+    assert "has been disabled" in str(err.value)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Test that a transient output effectively has no address after processing (meaning it was properly deleted) and test that we cannot create a new task that depend on this model as an input.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Sometimes ago I introduced a very basic test for transient outputs that just checked if the flag was set. Since then I made some progress and completed the work on the backend side to disable transient outputs properly. It's now time to test the full pipeline.

This test is simpler than the old `test_compute_plan_remove_intermediary_model` because here we are only checking the generic use case: a task with a transient outputs and not a complete workflow with train/predic/test. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Running the test against a locally deployed Substra stack.