### PR TITLE
test: add container image build logs tests (docker+remote)

### DIFF
--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -178,30 +178,6 @@ def test_tuples_execution_on_different_organizations(
     assert list(testtuple.test.perfs.values())[0] == pytest.approx(2)
 
 
-@pytest.mark.remote_only
-@pytest.mark.slow
-@pytest.mark.parametrize(
-    "dockerfile",
-    [
-        "INVALID DOCKERFILE",
-        "FROM scratch\nENTRYPOINT invalid_entrypoint_form",
-        'FROM scratch\nENTRYPOINT ["python", "script.py"]\nRUN invalid command',
-    ],
-)
-def test_traintuple_build_failure(dockerfile, factory, client, default_dataset):
-    """Invalid Dockerfile is causing traintuple failure."""
-
-    spec = factory.create_algo(AlgoCategory.simple, dockerfile=dockerfile)
-    algo = client.add_algo(spec)
-    spec = factory.create_traintuple(algo=algo, inputs=default_dataset.train_data_inputs)
-    traintuple = client.add_traintuple(spec)
-    traintuple = client.wait(traintuple, raises=False)
-
-    assert traintuple.status == Status.failed
-    assert traintuple.error_type == substra.sdk.models.TaskErrorType.build
-    assert traintuple.train.models is None
-
-
 @pytest.mark.slow
 @pytest.mark.subprocess_skip
 def test_algo_build_failure(factory, network, default_dataset_1):


### PR DESCRIPTION
Companion PRs:
- https://github.com/Substra/substra-backend/pull/483 (main PR)
- https://github.com/Substra/orchestrator/pull/38
- https://github.com/Substra/substra/pull/295
- https://github.com/Substra/substra-tests/pull/218 (this PR)
- https://github.com/Substra/substra-frontend/pull/116
- https://github.com/Substra/substra-documentation/pull/184

--- 

Previously, only execution errors had logs. Now, build errors have logs too.