### PR TITLE
refactor: replace substra-tools Docker image name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Update code owners (#229)
-- BREAKING: Update substratools Docker image (#442)
+- BREAKING: Update substratools Docker image (#230)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Update code owners (#229)
-- BREAKING: Update substratools Docker image (#230)
+- Update substratools Docker image (#230)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Update code owners (#229)
+- BREAKING: Update substratools Docker image (#442)
 
 ### Added
 

--- a/substratest/settings.py
+++ b/substratest/settings.py
@@ -13,7 +13,7 @@ _DEFAULT_NETWORK_CONFIGURATION_PATH = os.path.join(_CURRENT_DIR, "../", "values.
 _SUBSTRA_TESTS_CONFIG_FILEPATH = os.getenv("SUBSTRA_TESTS_CONFIG_FILEPATH", _DEFAULT_NETWORK_CONFIGURATION_PATH)
 
 _DEFAULT_SUBSTRA_TOOLS_TAG_LOCAL = (
-    f"latest-nvidiacuda11.6.0-base-ubuntu20.04-python{sys.version_info.major}.{sys.version_info.minor}"
+    f"latest-nvidiacuda11.8.0-base-ubuntu22.04-python{sys.version_info.major}.{sys.version_info.minor}"
 )
 _DEFAULT_SUBSTRA_TOOLS_TAG_REMOTE = "latest"
 

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -8,7 +8,7 @@ from substratest.fl_interface import OutputIdentifiers
 def test_gpu(factory, client, org_idx, default_datasets, workers):
     """Test that the task can see the GPU"""
     org_idx = 0
-    nvidia_drivers = "nvidiacuda11.6.0-base-ubuntu20.04"
+    nvidia_drivers = "nvidiacuda11.8.0-base-ubuntu22.04"
 
     # Need the base image, the minimal image does not have pip
     dockerfile = f"""


### PR DESCRIPTION
Signed-off-by: Guilhem Barthes <guilhem.barthes@owkin.com>

## Summary

Update substratools Docker image name to the new one using lastr Ubuntu LTS (22.04) and supporting Python 3.10.

## Companion PR

- https://github.com/Substra/substra/pull/316
- https://github.com/Substra/substra-tools/pull/68
- https://github.com/Substra/substrafl/pull/49
- https://github.com/Substra/substra-documentation/pull/222