### PR TITLE
feat: add test for compute plan creator

### DIFF
--- a/substratest/channel.py
+++ b/substratest/channel.py
@@ -12,6 +12,7 @@ _OVERRIDDEN_FIELDS = (
     # storage address is replaced by each backend with its internal address
     "storage_address",
     "host",
+    # creator is known only by the owning organization
     "creator",
 )
 

--- a/substratest/channel.py
+++ b/substratest/channel.py
@@ -12,6 +12,7 @@ _OVERRIDDEN_FIELDS = (
     # storage address is replaced by each backend with its internal address
     "storage_address",
     "host",
+    "creator",
 )
 
 

--- a/tests/test_synchronized.py
+++ b/tests/test_synchronized.py
@@ -94,8 +94,12 @@ def test_synchronized_computeplan(clients, factory, channel, current_client):
     # create algo
     cp_spec = factory.create_compute_plan()
     compute_plan = current_client.add_compute_plan(cp_spec)
+    assert compute_plan.creator != "external"
 
-    compute_plan = current_client.wait(compute_plan)
+    # Compute plan are created with None value as duration, but for filtering and sorting purpose
+    # remote api's get_compute_plan returns 0 as duration instead. We need to set it to 0
+    # here instead of None for wait_for_asset_synchronized to pass on compute plan.
+    compute_plan.duration = 0
     channel.wait_for_asset_synchronized(compute_plan)
 
     external_cp = clients[1].get_compute_plan(key=compute_plan.key)

--- a/tests/test_synchronized.py
+++ b/tests/test_synchronized.py
@@ -84,3 +84,20 @@ def test_synchronized_traintuple(clients, factory, channel, current_client, work
     traintuple = current_client.add_task(spec)
     traintuple = current_client.wait(traintuple)
     channel.wait_for_asset_synchronized(traintuple)
+
+
+@pytest.mark.remote_only
+def test_synchronized_computeplan(clients, factory, channel, current_client):
+    if len(clients) < 2:
+        pytest.skip("requires at least 2 organizations")
+
+    # create algo
+    cp_spec = factory.create_compute_plan()
+    compute_plan = current_client.add_compute_plan(cp_spec)
+
+    compute_plan = current_client.wait(compute_plan)
+    channel.wait_for_asset_synchronized(compute_plan)
+
+    external_cp = clients[1].get_compute_plan(key=compute_plan.key)
+    # creator should not be propagated to another org
+    assert external_cp.creator == "external"


### PR DESCRIPTION
This PR adds a test to verify that creator username is not propagated to other organization and instead replaced by external.

Companion PRs:
- https://github.com/Substra/substra-backend/pull/511
- https://github.com/Substra/substra-frontend/pull/124
- https://github.com/Substra/substra/pull/331