### PR TITLE
test: custom metric task with several outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Test of a test task returning several performances ([#251](https://github.com/Substra/substra-tests/pull/251))
+
 ## [0.39.0] - 2023-03-31
 
 ### Changed

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -47,7 +47,6 @@ class Client:
         future_polling_period: int,
         token: Optional[str] = None,
     ):
-
         super().__init__()
 
         self.organization_id = organization_id
@@ -192,7 +191,6 @@ class Client:
         return getter(asset.key)
 
     def wait(self, asset, raises=True, timeout=None):
-
         if timeout is None:
             timeout = self.future_timeout
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -226,7 +226,6 @@ def default_data_env(cfg, network, client_mode):
         datasets = []
         metrics = []
         for index, client in enumerate(network.clients):
-
             # create dataset
             spec = f.create_dataset()
             dataset = client.add_dataset(spec)

--- a/tests/test_data_samples_order.py
+++ b/tests/test_data_samples_order.py
@@ -183,7 +183,6 @@ def dataset(factory, client):
 
 
 def test_task_data_samples_relative_order(factory, client, dataset, worker):
-
     # Format TEMPLATE_FUNCTION_SCRIPT with current data_sample_keys
     function_script = TEMPLATE_FUNCTION_SCRIPT.format(
         data_sample_keys=dataset.train_data_sample_keys,

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -285,7 +285,7 @@ import substratools as tools
 def score(inputs, outputs, task_properties):
     tools.save_performance(1, outputs['{identifier_1}'])
     tools.save_performance(2, outputs['{identifier_2}'])
-
+az
 if __name__ == '__main__':
     tools.execute()
     """

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext as does_not_raise
-
 import pytest
 import substra
 from substra.sdk.models import Status

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -2,13 +2,12 @@ from contextlib import nullcontext as does_not_raise
 
 import pytest
 import substra
-
-from substra.sdk.schemas import AssetKind
 from substra.sdk.models import Status
-from substra.sdk.schemas import TaskSpec
+from substra.sdk.schemas import AssetKind
 from substra.sdk.schemas import ComputeTaskOutputSpec
-from substra.sdk.schemas import Permissions
 from substra.sdk.schemas import FunctionOutputSpec
+from substra.sdk.schemas import Permissions
+from substra.sdk.schemas import TaskSpec
 
 import substratest as sbt
 from substratest.factory import AugmentedDataset

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -285,7 +285,7 @@ import substratools as tools
 def score(inputs, outputs, task_properties):
     tools.save_performance(1, outputs['{identifier_1}'])
     tools.save_performance(2, outputs['{identifier_2}'])
-az
+
 if __name__ == '__main__':
     tools.execute()
     """

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -325,11 +325,11 @@ if __name__ == '__main__':
     testtask = client.wait(testtask)
     assert testtask.status == Status.done
     assert testtask.error_type is None
-    assert testtask.outputs[identifier_1].value == pytest.approx(1)
-    assert testtask.outputs[identifier_2].value == pytest.approx(2)
+    assert testtask.outputs[identifier_1].value == 1
+    assert testtask.outputs[identifier_2].value == 2
 
 
-def test_testtask_with_same_output_identifer(factory, client, default_dataset, worker):
+def test_testtask_with_same_output_identifer(factory, client):
     identifier_1 = "same_name"
     identifier_2 = "same_name"
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,7 +1,14 @@
+from contextlib import nullcontext as does_not_raise
+
 import pytest
 import substra
+
+from substra.sdk.schemas import AssetKind
 from substra.sdk.models import Status
 from substra.sdk.schemas import TaskSpec
+from substra.sdk.schemas import ComputeTaskOutputSpec
+from substra.sdk.schemas import Permissions
+from substra.sdk.schemas import FunctionOutputSpec
 
 import substratest as sbt
 from substratest.factory import AugmentedDataset
@@ -249,6 +256,90 @@ def test_task_execution_failure(factory, network, default_dataset_1, worker):
             logs = client.download_logs(traintask.key)
             assert "Traceback (most recent call last):" in logs
             assert client.get_logs(traintask.key) == logs
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "identifier_1,identifier_2,expectation",
+    [
+        (
+            "name_1",
+            "name_2",
+            does_not_raise(),
+        ),
+        (
+            "same_name",
+            "same_name",
+            pytest.raises(ValueError),
+        ),
+    ],
+)
+def test_custom_testtask(factory, client, default_dataset, worker, identifier_1, identifier_2, expectation):
+    """Test with a test task with several performance output."""
+
+    custom_metric_script = f"""
+import json
+import substratools as tools
+
+@tools.register
+def score(inputs, outputs, task_properties):
+    tools.save_performance(1, outputs['{identifier_1}'])
+    tools.save_performance(2, outputs['{identifier_2}'])
+
+if __name__ == '__main__':
+    tools.execute()
+    """
+
+    # add test data samples / dataset / metric on organization 1
+    spec = factory.create_function(FunctionCategory.simple)
+    function = client.add_function(spec)
+
+    predict_function_spec = factory.create_function(FunctionCategory.predict)
+    predict_function = client.add_function(predict_function_spec)
+
+    # add traintask on organization 2; should execute on organization 2 (dataset located on organization 2)
+    spec = factory.create_traintask(
+        function=function,
+        inputs=default_dataset.train_data_inputs,
+        worker=worker,
+    )
+    traintask = client.add_task(spec)
+    traintask = client.wait(traintask)
+
+    # add testtask; should execute on organization 1 (default_dataset_1 is located on organization 1)
+    spec = factory.create_predicttask(
+        function=predict_function,
+        inputs=default_dataset.test_data_inputs + FLTaskInputGenerator.train_to_predict(traintask.key),
+        worker=worker,
+    )
+    predicttask = client.add_task(spec)
+    predicttask = client.wait(predicttask)
+
+    spec = factory.create_function(category=FunctionCategory.metric, py_script=custom_metric_script)
+    spec.outputs = [
+        FunctionOutputSpec(identifier=identifier_1, kind=AssetKind.performance.value, multiple=False),
+        FunctionOutputSpec(identifier=identifier_2, kind=AssetKind.performance.value, multiple=False),
+    ]
+
+    with expectation:
+        metric = client.add_function(spec)
+
+        spec = factory.create_testtask(
+            function=metric,
+            inputs=default_dataset.test_data_inputs + FLTaskInputGenerator.predict_to_test(predicttask.key),
+            outputs={
+                identifier_1: ComputeTaskOutputSpec(permissions=Permissions(public=True, authorized_ids=[])),
+                identifier_2: ComputeTaskOutputSpec(permissions=Permissions(public=True, authorized_ids=[])),
+            },
+            worker=worker,
+        )
+
+        testtask = client.add_task(spec)
+        testtask = client.wait(testtask)
+        assert testtask.status == Status.done
+        assert testtask.error_type is None
+        assert testtask.outputs[identifier_1].value == pytest.approx(1)
+        assert testtask.outputs[identifier_2].value == pytest.approx(2)
 
 
 @pytest.mark.slow

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -664,7 +664,6 @@ def test_execution_compute_plan_canceled(factory, client, default_dataset, cfg, 
 @pytest.mark.slow
 @pytest.mark.remote_only
 def test_compute_plan_no_batching(factory, client, default_dataset, worker):
-
     spec = factory.create_function(FunctionCategory.simple)
     function = client.add_function(spec)
 

--- a/tests/test_hybrid_mode.py
+++ b/tests/test_hybrid_mode.py
@@ -22,7 +22,6 @@ pytestmark = pytest.mark.skipif(not docker_available(), reason="requires docker"
 @pytest.mark.remote_only
 @pytest.mark.slow
 def test_execution_debug(client, hybrid_client, debug_factory, default_dataset):
-
     spec = debug_factory.create_function(FunctionCategory.simple)
     simple_function = client.add_function(spec)
     spec = debug_factory.create_function(FunctionCategory.predict)
@@ -93,7 +92,6 @@ def test_debug_compute_plan_aggregate_composite(network, client, hybrid_client, 
         # create composite traintask on each organization
         composite_traintask_keys = []
         for index, dataset in enumerate(default_datasets):
-
             if previous_aggregate_task_key:
                 input_models = FLTaskInputGenerator.composite_to_local(
                     previous_composite_traintask_keys[index]
@@ -129,7 +127,6 @@ def test_debug_compute_plan_aggregate_composite(network, client, hybrid_client, 
 
     # last round: create associated testtask
     for composite_traintask_key, dataset, metric in zip(previous_composite_traintask_keys, default_datasets, metrics):
-
         spec = cp_spec.create_predicttask(
             function=predict_function_composite,
             inputs=dataset.train_data_inputs + FLTaskInputGenerator.composite_to_predict(composite_traintask_key),

--- a/tests/workflows/mnist-fedavg/assets/composite_function.py
+++ b/tests/workflows/mnist-fedavg/assets/composite_function.py
@@ -89,7 +89,6 @@ def train(inputs, outputs, task_properties):
 
 @tools.register
 def predict(inputs, outputs, task_properties):
-
     trunk_model = load_trunk_model(inputs["shared"])
 
     X = inputs["datasamples"]["X"]


### PR DESCRIPTION
# Description

Performance asset were unique regarding their compute task key, and the function key they were computed from. Or, we want to have the possibility to have a function that outputs several performance and store them in the same task.

This implies two main things:
   - Performance are now unique regarding the compute task key, the function key AND the output identifier
   - The frontend must serialize regarding the identifier, and not the function key

The PR batch modify both the orchestrator and backend db in order to include the identifier as an additional unique condition.
In the backend, we use the ComputeTaskOutput as primary key directly.

## Companion PR

- https://github.com/Substra/substra-backend/pull/634
- https://github.com/Substra/substra-tests/pull/251 (main)
- https://github.com/Substra/orchestrator/pull/197
- https://github.com/Substra/substra-frontend/pull/194
- https://github.com/Substra/substra/pull/357

## E2E tests
- https://github.com/owkin/substra-ci/actions/runs/4872054802