### PR TITLE
feat: use new substra functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - BREAKING: rename Algo to Function (#243)
+- Replace `task.outputs[identifier].value` by `client.get_task_output_asset(task.key, identifier).asset` (#256)
 
 ## [0.38.1] - 2023-02-06
 

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -90,6 +90,15 @@ class Client:
 
     def list_compute_plan(self, *args, **kwargs):
         return self._client.list_compute_plan(*args, **kwargs)
+    
+    def list_task_input_assets(self, *args, **kwargs):
+        return self._client.list_task_input_assets(*args, **kwargs)
+    
+    def list_task_output_assets(self, *args, **kwargs):
+        return self._client.list_task_output_assets(*args, **kwargs)
+        
+    def get_task_output_asset(self, *args, **kwargs):
+        return self._client.get_task_output_asset(*args, **kwargs)
 
     def get_compute_plan(self, *args, **kwargs):
         return self._client.get_compute_plan(*args, **kwargs)

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -187,7 +187,6 @@ class Client:
             models.Dataset: self.get_dataset,
             models.Function: self.get_function,
             models.Task: self.get_task,
-            models.SummaryTask: self.get_task,
             models.ComputePlan: self.get_compute_plan,
             models.DataSample: self.get_data_sample,
         }

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -90,13 +90,13 @@ class Client:
 
     def list_compute_plan(self, *args, **kwargs):
         return self._client.list_compute_plan(*args, **kwargs)
-    
+
     def list_task_input_assets(self, *args, **kwargs):
         return self._client.list_task_input_assets(*args, **kwargs)
-    
+
     def list_task_output_assets(self, *args, **kwargs):
         return self._client.list_task_output_assets(*args, **kwargs)
-        
+
     def get_task_output_asset(self, *args, **kwargs):
         return self._client.get_task_output_asset(*args, **kwargs)
 

--- a/tests/test_data_samples_order.py
+++ b/tests/test_data_samples_order.py
@@ -205,9 +205,8 @@ def test_task_data_samples_relative_order(factory, client, dataset, worker):
     # Ensure the order of the data sample keys is correct at 2 levels: :
     #  1. In the returned traintask
     #  2. In the train method of the function. If the order is incorrect, wait() will fail.
-    traintask_input_assets = client.get_input_assets(traintask.key)
     assert [
-        i.key for i in traintask_input_assets if i.identifier == InputIdentifiers.datasamples
+        i.asset_key for i in traintask.inputs if i.identifier == InputIdentifiers.datasamples
     ] == dataset.train_data_sample_keys
     client.wait(traintask)
 
@@ -261,9 +260,8 @@ def test_composite_traintask_data_samples_relative_order(factory, client, datase
     # Ensure the order of the data sample keys is correct at 2 levels: :
     #  1. In the returned composite traintask
     #  2. In the train method of the function. If the order is incorrect, wait() will fail.
-    composite_traintask_input_assets = client.get_input_assets(composite_traintask.key)
     assert [
-        i.asset.key for i in composite_traintask_input_assets if i.identifier == InputIdentifiers.datasamples
+        i.asset_key for i in composite_traintask.inputs if i.identifier == InputIdentifiers.datasamples
     ] == dataset.train_data_sample_keys
     client.wait(composite_traintask)
 

--- a/tests/test_data_samples_order.py
+++ b/tests/test_data_samples_order.py
@@ -205,8 +205,9 @@ def test_task_data_samples_relative_order(factory, client, dataset, worker):
     # Ensure the order of the data sample keys is correct at 2 levels: :
     #  1. In the returned traintask
     #  2. In the train method of the function. If the order is incorrect, wait() will fail.
+    traintask_input_assets = client.get_input_assets(traintask.key)
     assert [
-        i.asset_key for i in traintask.inputs if i.identifier == InputIdentifiers.datasamples
+        i.key for i in traintask_input_assets if i.identifier == InputIdentifiers.datasamples
     ] == dataset.train_data_sample_keys
     client.wait(traintask)
 
@@ -260,8 +261,9 @@ def test_composite_traintask_data_samples_relative_order(factory, client, datase
     # Ensure the order of the data sample keys is correct at 2 levels: :
     #  1. In the returned composite traintask
     #  2. In the train method of the function. If the order is incorrect, wait() will fail.
+    composite_traintask_input_assets = client.get_input_assets(composite_traintask.key)
     assert [
-        i.asset_key for i in composite_traintask.inputs if i.identifier == InputIdentifiers.datasamples
+        i.asset.key for i in composite_traintask_input_assets if i.identifier == InputIdentifiers.datasamples
     ] == dataset.train_data_sample_keys
     client.wait(composite_traintask)
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -42,11 +42,8 @@ def test_tasks_execution_on_same_organization(factory, network, client, default_
     assert traintask.error_type is None
     assert traintask.metadata == {"foo": "bar"}
     assert len(traintask.outputs) == 1
-    assert traintask.outputs[OutputIdentifiers.model].value is not None
-
-    if network.options.enable_model_download:
-        model = traintask.outputs[OutputIdentifiers.model].value
-        assert client.download_model(model.key) == b'{"value": 2.2}'
+    out_models = client.get_task_models(traintask.key)
+    assert len(out_models) == 1
 
     # check we can add twice the same traintask
     spec = get_traintask_spec()
@@ -121,10 +118,11 @@ def test_federated_learning_workflow(factory, client, default_datasets, workers)
         )
         traintask = client.add_task(spec)
         traintask = client.wait(traintask)
+        out_models = client.get_task_models(traintask.key)
         assert traintask.status == Status.done
         assert traintask.error_type is None
         assert len(traintask.outputs) == 1
-        assert traintask.outputs[OutputIdentifiers.model].value is not None
+        assert len(out_models) == 1
         assert traintask.tag == "foo"
         assert traintask.compute_plan_key  # check it is not None or ''
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -330,8 +330,10 @@ if __name__ == '__main__':
     testtask = client.wait(testtask)
     assert testtask.status == Status.done
     assert testtask.error_type is None
-    assert testtask.outputs[identifier_1].value == 1
-    assert testtask.outputs[identifier_2].value == 2
+    output_1 = client.get_task_output_asset(testtask.key, identifier_1)
+    output_2 = client.get_task_output_asset(testtask.key, identifier_2)
+    assert output_1.asset == 1
+    assert output_2.asset == 2
 
 
 def test_testtask_with_same_output_identifer(factory, client):

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -42,8 +42,12 @@ def test_tasks_execution_on_same_organization(factory, network, client, default_
     assert traintask.error_type is None
     assert traintask.metadata == {"foo": "bar"}
     assert len(traintask.outputs) == 1
-    out_models = client.get_task_models(traintask.key)
-    assert len(out_models) == 1
+    client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+    assert output.asset is not None
+
+    if network.options.enable_model_download:
+        model = output.asset
+        assert client.download_model(model.key) == b'{"value": 2.2}'
 
     # check we can add twice the same traintask
     spec = get_traintask_spec()

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -70,7 +70,8 @@ def test_tasks_execution_on_same_organization(factory, network, client, default_
     testtask = client.wait(testtask)
     assert testtask.status == Status.done
     assert testtask.error_type is None
-    assert testtask.outputs[OutputIdentifiers.performance].value == pytest.approx(2)
+    performance = client.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
+    assert performance.asset == pytest.approx(2)
 
     # add a traintask depending on first traintask
     first_traintask_key = traintask.key
@@ -193,7 +194,8 @@ def test_tasks_execution_on_different_organizations(
     assert testtask.status == Status.done
     assert testtask.error_type is None
     assert testtask.worker == client_1.organization_id
-    assert testtask.outputs[OutputIdentifiers.performance].value == pytest.approx(2)
+    performance = client_1.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
+    assert performance.asset == pytest.approx(2)
 
 
 @pytest.mark.slow
@@ -469,7 +471,8 @@ def test_composite_traintasks_execution(factory, client, default_dataset, defaul
     testtask = client.wait(testtask)
     assert testtask.status == Status.done
     assert testtask.error_type is None
-    assert testtask.outputs[OutputIdentifiers.performance].value == pytest.approx(32)
+    performance = client.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
+    assert performance.asset == pytest.approx(32)
 
     # list composite traintask
     composite_traintasks = client.list_task()
@@ -777,7 +780,8 @@ def test_aggregate_composite_traintasks(factory, network, clients, default_datas
         testtask = clients[0].add_task(spec)
         testtask = clients[0].wait(testtask)
         # y_true: [20], y_pred: [52.0], result: 32.0
-        assert testtask.outputs[OutputIdentifiers.performance].value == pytest.approx(32 + index)
+        performance = clients[0].get_task_output_asset(testtask.key, OutputIdentifiers.performance)
+        assert performance.asset == pytest.approx(32 + index)
 
     spec = factory.create_predicttask(
         function=predict_function,
@@ -796,7 +800,8 @@ def test_aggregate_composite_traintasks(factory, network, clients, default_datas
     testtask = clients[0].add_task(spec)
     testtask = clients[0].wait(testtask)
     # y_true: [20], y_pred: [28.0], result: 8.0
-    assert testtask.outputs[OutputIdentifiers.performance].value == pytest.approx(8)
+    performance = clients[0].get_task_output_asset(testtask.key, OutputIdentifiers.performance)
+    assert performance.asset == pytest.approx(8)
 
     if network.options.enable_model_download:
         # Optional (if "enable_model_download" is True): ensure we can export out-models.
@@ -875,7 +880,8 @@ def test_use_data_sample_located_in_shared_path(factory, network, client, organi
     testtask = client.wait(testtask)
     assert testtask.status == Status.done
     assert testtask.error_type is None
-    assert testtask.outputs[OutputIdentifiers.performance].value == pytest.approx(2)
+    performance = client.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
+    assert performance.asset == pytest.approx(2)
 
 
 @pytest.mark.subprocess_skip

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -349,7 +349,7 @@ def test_testtask_with_same_output_identifer(factory, client):
         FunctionOutputSpec(identifier=identifier_2, kind=AssetKind.performance.value, multiple=False),
     ]
 
-    with pytest.raises(TaskAssetNotFoundError):
+    with pytest.raises(ValueError):
         client.add_function(spec)
 
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -360,7 +360,6 @@ def test_composite_traintask_execution_failure(factory, client, default_dataset,
 
         assert composite_traintask.status == Status.failed
         assert composite_traintask.error_type == substra.sdk.models.TaskErrorType.execution
-        print(client.list_task_output_assets(composite_traintask.key))
         with pytest.raises(ValueError):
             client.get_task_output_asset(composite_traintask.key, OutputIdentifiers.local)
         

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext as does_not_raise
-
 import pytest
 import substra
 from substra.sdk.exceptions import TaskAssetNotFoundError
@@ -45,8 +43,8 @@ def test_tasks_execution_on_same_organization(factory, network, client, default_
     assert traintask.error_type is None
     assert traintask.metadata == {"foo": "bar"}
     assert len(traintask.outputs) == 1
-    with does_not_raise():
-        output = client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+    # Raises an exception if the output asset have not been created
+    output = client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
 
     if network.options.enable_model_download:
         model = output.asset
@@ -176,8 +174,8 @@ def test_tasks_execution_on_different_organizations(
     assert traintask.status == Status.done
     assert traintask.error_type is None
     assert len(traintask.outputs) == 1
-    with does_not_raise():
-        client_1.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+    # Raises an exception if the output asset have not been created
+    client_1.get_task_output_asset(traintask.key, OutputIdentifiers.model)
     assert traintask.worker == client_2.organization_id
 
     # add testtask; should execute on organization 1 (default_dataset_1 is located on organization 1)
@@ -878,8 +876,9 @@ def test_use_data_sample_located_in_shared_path(factory, network, client, organi
     traintask = client.wait(traintask)
     assert traintask.status == Status.done
     assert traintask.error_type is None
-    with does_not_raise():
-        client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+
+    # Raises an exception if the output asset have not been created
+    client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
 
     # create testtask
     spec = factory.create_predicttask(

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -42,7 +42,7 @@ def test_tasks_execution_on_same_organization(factory, network, client, default_
     assert traintask.error_type is None
     assert traintask.metadata == {"foo": "bar"}
     assert len(traintask.outputs) == 1
-    client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+    output = client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
     assert output.asset is not None
 
     if network.options.enable_model_download:
@@ -366,9 +366,9 @@ def test_composite_traintask_execution_failure(factory, client, default_dataset,
         assert composite_traintask.error_type == substra.sdk.models.TaskErrorType.execution
         with pytest.raises(ValueError):
             client.get_task_output_asset(composite_traintask.key, OutputIdentifiers.local)
-        
+
         with pytest.raises(ValueError):
-             client.get_task_output_asset(composite_traintask.key, OutputIdentifiers.shared)
+            client.get_task_output_asset(composite_traintask.key, OutputIdentifiers.shared)
         assert "Traceback (most recent call last):" in client.download_logs(composite_traintask.key)
 
     elif client.backend_mode in (substra.BackendType.LOCAL_SUBPROCESS, substra.BackendType.LOCAL_DOCKER):

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -585,8 +585,8 @@ def test_compute_plan_aggregate_composite_traintasks(  # noqa: C901
     # Check that permissions were correctly set
     for task_id in [ct.task_id for ct in composite_traintask_specs]:
         task = clients[0].get_task(task_id)
-        trunk = task.outputs[OutputIdentifiers.shared].permissions
-        assert len(trunk.process.authorized_ids) == len(clients)
+        trunk_permissions = task.outputs[OutputIdentifiers.shared].permissions
+        assert len(trunk_permissions.process.authorized_ids) == len(clients)
 
 
 def test_compute_plan_circular_dependency_failure(factory, client, default_dataset, worker):

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -128,11 +128,14 @@ def test_compute_plan_simple(
 
     # check testtask perfs
     assert len(testtask.outputs) == 1
-    assert testtask.outputs[OutputIdentifiers.performance].value == pytest.approx(4)
+    performance = client_1.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
+    assert performance.asset == pytest.approx(4)
 
     # check compute plan perfs
     performances = client_1.get_performances(cp.key)
     assert all(len(val) == 1 for val in performances.dict().values())
+    output = client_1.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
+    assert output.asset == performances.performance[0]
 
     # XXX as the first two tasks have the same rank, there is currently no way to know
     #     which one will be returned first

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -133,7 +133,6 @@ def test_compute_plan_simple(
     # check compute plan perfs
     performances = client_1.get_performances(cp.key)
     assert all(len(val) == 1 for val in performances.dict().values())
-    assert testtask.outputs[OutputIdentifiers.performance].value == performances.performance[0]
 
     # XXX as the first two tasks have the same rank, there is currently no way to know
     #     which one will be returned first
@@ -561,7 +560,7 @@ def test_compute_plan_aggregate_composite_traintasks(  # noqa: C901
                 )
                 == 1
             )
-        print(task.inputs)
+
         if len(task.inputs) > 2:
             assert (
                 len(
@@ -583,8 +582,8 @@ def test_compute_plan_aggregate_composite_traintasks(  # noqa: C901
     # Check that permissions were correctly set
     for task_id in [ct.task_id for ct in composite_traintask_specs]:
         task = clients[0].get_task(task_id)
-        trunk = task.outputs[OutputIdentifiers.shared].value
-        assert len(trunk.permissions.process.authorized_ids) == len(clients)
+        trunk = task.outputs[OutputIdentifiers.shared].permissions
+        assert len(trunk.process.authorized_ids) == len(clients)
 
 
 def test_compute_plan_circular_dependency_failure(factory, client, default_dataset, worker):

--- a/tests/test_hybrid_mode.py
+++ b/tests/test_hybrid_mode.py
@@ -39,7 +39,8 @@ def test_execution_debug(client, hybrid_client, debug_factory, default_dataset):
     )
     traintask = hybrid_client.add_task(spec)
     assert traintask.status == models.Status.done
-    assert traintask.outputs[OutputIdentifiers.model].value is not None
+    output = hybrid_client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+    assert output.asset is not None
 
     # Add the testtask
     spec = debug_factory.create_predicttask(

--- a/tests/test_hybrid_mode.py
+++ b/tests/test_hybrid_mode.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext as does_not_raise
-
 import docker
 import pytest
 from substra.sdk import models
@@ -41,8 +39,9 @@ def test_execution_debug(client, hybrid_client, debug_factory, default_dataset):
     )
     traintask = hybrid_client.add_task(spec)
     assert traintask.status == models.Status.done
-    with does_not_raise():
-        hybrid_client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+
+    # Raises an exception if the output asset have not been created
+    hybrid_client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
 
     # Add the testtask
     spec = debug_factory.create_predicttask(

--- a/tests/test_hybrid_mode.py
+++ b/tests/test_hybrid_mode.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext as does_not_raise
+
 import docker
 import pytest
 from substra.sdk import models
@@ -39,8 +41,8 @@ def test_execution_debug(client, hybrid_client, debug_factory, default_dataset):
     )
     traintask = hybrid_client.add_task(spec)
     assert traintask.status == models.Status.done
-    output = hybrid_client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
-    assert output.asset is not None
+    with does_not_raise():
+        hybrid_client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
 
     # Add the testtask
     spec = debug_factory.create_predicttask(

--- a/tests/test_hybrid_mode.py
+++ b/tests/test_hybrid_mode.py
@@ -61,7 +61,8 @@ def test_execution_debug(client, hybrid_client, debug_factory, default_dataset):
     )
     testtask = hybrid_client.add_task(spec)
     assert testtask.status == models.Status.done
-    assert testtask.outputs[OutputIdentifiers.performance].value == 3
+    performance = hybrid_client.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
+    assert performance.asset == 3
 
 
 @pytest.mark.remote_only

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -173,8 +173,9 @@ def test_permissions(permissions_1, permissions_2, expected_permissions, factory
     traintask = client_1.wait(traintask)
 
     # check the compute task executed on the correct worker
-    output = client_1.get_task_output_asset(traintask.key, OutputIdentifiers.model)
-    assert output.asset is not None
+    with does_not_raise():
+        client_1.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+
     assert traintask.worker == client_1.organization_id
 
     # check the permissions

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -173,7 +173,8 @@ def test_permissions(permissions_1, permissions_2, expected_permissions, factory
     traintask = client_1.wait(traintask)
 
     # check the compute task executed on the correct worker
-    assert traintask.outputs[OutputIdentifiers.model].value is not None
+    output = client_1.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+    assert output.asset is not None
     assert traintask.worker == client_1.organization_id
 
     # check the permissions

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -173,8 +173,8 @@ def test_permissions(permissions_1, permissions_2, expected_permissions, factory
     traintask = client_1.wait(traintask)
 
     # check the compute task executed on the correct worker
-    with does_not_raise():
-        client_1.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+    # Raises an exception if the output asset have not been created
+    client_1.get_task_output_asset(traintask.key, OutputIdentifiers.model)
 
     assert traintask.worker == client_1.organization_id
 

--- a/tests/workflows/mnist-fedavg/test_workflow.py
+++ b/tests/workflows/mnist-fedavg/test_workflow.py
@@ -395,7 +395,7 @@ def test_mnist(factory, inputs, clients, cfg: Settings, workers: typing.List[str
     performances = client.get_performances(cp.key)
     perf_dict = {task_key: perf for task_key, perf in zip(performances.task_key, performances.performance)}
     testtasks = sorted(testtasks, key=lambda x: (x.rank, x.worker))
-    
+
     for testtask in testtasks:
         output = client.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
         print(

--- a/tests/workflows/mnist-fedavg/test_workflow.py
+++ b/tests/workflows/mnist-fedavg/test_workflow.py
@@ -397,11 +397,10 @@ def test_mnist(factory, inputs, clients, cfg: Settings, workers: typing.List[str
     testtasks = sorted(testtasks, key=lambda x: (x.rank, x.worker))
 
     for testtask in testtasks:
-        output = client.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
         print(
             f"testtask({testtask.worker}) - rank {testtask.rank} "
             f"- round {testtask.metadata['round_idx']} "
-            f"perf: {output.asset}"
+            f"perf: {perf_dict[testtask.key]}"
         )
 
     nb_samples = (cfg.mnist_workflow.train_samples, cfg.mnist_workflow.test_samples)
@@ -409,12 +408,7 @@ def test_mnist(factory, inputs, clients, cfg: Settings, workers: typing.List[str
     # performance should be deterministic a fixed number of samples:
     if nb_samples in _EXPECTED_RESULTS.keys():
         expected_perf = _EXPECTED_RESULTS[nb_samples]
-        assert all(
-            [
-                client.get_task_output_asset(testtask.key, OutputIdentifiers.performance).asset == pytest.approx(perf)
-                for (perf, testtask) in zip(expected_perf, testtasks)
-            ]
-        )
+        assert all(perf_dict[testtask.key] == pytest.approx(perf) for (perf, testtask) in zip(expected_perf, testtasks))
     else:
         # check perf is as good as expected: after 20 rounds we expect a performance of
         # around 0.86. To avoid a flaky test a lower performance is expected.


### PR DESCRIPTION
## Related issue

- https://github.com/Substra/substra-backend/pull/509
- https://github.com/Substra/substra/pull/361
- https://github.com/Substra/substrafl/pull/129

## Summary

Adapt tests to:
- remove usage of `.value` in task outputs
- use new functions to get input/output assets.

Fixes FL-652

## Test

Ci in `substra` companion PR