### PR TITLE
fix: use `_token` instead of `token`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -377,5 +377,5 @@ def hybrid_client(cfg, client):
         password=organization.password,
         future_timeout=cfg.options.future_timeout,
         future_polling_period=cfg.options.future_polling_period,
-        token=client.token,
+        token=client._token,
     )


### PR DESCRIPTION
# Summary

Fix https://github.com/Substra/substra-tests/pull/257 where a `token` (attribute of `substratest.Client`) was still in use instead of `_token` (already available in `substra.Client`, now mother class of `substratest.Client`)