### PR TITLE
fix: `wait_model_deletion` didn't update model

### DIFF
--- a/substratest/client.py
+++ b/substratest/client.py
@@ -201,7 +201,7 @@ class Client(substra.Client):
                 raise errors.FutureTimeoutError(f"Future timeout waiting on model deletion for {model_key}")
 
             time.sleep(self.future_polling_period)
-            super().get_model(model_key)
+            model = super().get_model(model_key)
 
     def update_function(self, function, name, *args, **kwargs):
         return super().update_function(function.key, name, *args, **kwargs)


### PR DESCRIPTION
# Summary

PR https://github.com/Substra/substra-tests/pull/257 broke `wait_model_deletion` as a `model =` is missing in the while loop ; currently the `wait_model_deletion` is checking that a model is deleted without never updating the model.

Before PR #257 :
 ```
 def wait_model_deletion(self, model_key):
        ...
        model = self._client.get_model(model_key)
        while model.address:
           ...
            time.sleep(self.future_polling_period)
            model = self._client.get_model(model_key)
```

After # 257:
 ```
 def wait_model_deletion(self, model_key):
        ...
        model = super().get_model(model_key)
        while model.address:
           ...
            time.sleep(self.future_polling_period)
            super().get_model(model_key)
```

After this one:
 ```
 def wait_model_deletion(self, model_key):
        ...
        model = super().get_model(model_key)
        while model.address:
           ...
            time.sleep(self.future_polling_period)
            model = super().get_model(model_key)
```