### PR TITLE
chore: remove models and model from input and output identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.42.0] - 2023-06-27
 
 ### Changed
- - Define test client (`substratest.client.Client`) as child class of `substra.Client` (#205)
+
+- Define test client (`substratest.client.Client`) as child class of `substra.Client` (#205)
 ([#257](https://github.com/Substra/substra-tests/pull/257))
+- Remove `model` and `models` for input and output identifiers in tests. Replace by `shared` instead. ([#261](https://github.com/Substra/substra-tests/pull/261))
 
 ## [0.41.0] - 2023-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove `model` and `models` for input and output identifiers in tests. Replace by `shared` instead. ([#261](https://github.com/Substra/substra-tests/pull/261))
+
 ## [0.42.0] - 2023-06-27
 
 ### Changed
 
 - Define test client (`substratest.client.Client`) as child class of `substra.Client` (#205)
 ([#257](https://github.com/Substra/substra-tests/pull/257))
-- Remove `model` and `models` for input and output identifiers in tests. Replace by `shared` instead. ([#261](https://github.com/Substra/substra-tests/pull/261))
 
 ## [0.41.0] - 2023-06-12
 

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -93,7 +93,7 @@ def train(inputs, outputs, task_properties):
     rank = task_properties['{InputIdentifiers.rank}']
 
     models = []
-    for m_path in inputs.get('{InputIdentifiers.models}', []):
+    for m_path in inputs.get('{InputIdentifiers.shared}', []):
         models.append(load_model(m_path))
 
     print(f'Train, get X: {{X}}, y: {{y}}, models: {{models}}')
@@ -109,12 +109,12 @@ def train(inputs, outputs, task_properties):
         res = {{'value': avg + err }}
 
     print(f'Train, return {{res}}')
-    save_model(res, outputs['{OutputIdentifiers.model}'])
+    save_model(res, outputs['{OutputIdentifiers.shared}'])
 
 @tools.register
 def predict(inputs, outputs, task_properties):
     X = inputs['{InputIdentifiers.datasamples}'][0]
-    model = load_model(inputs['{InputIdentifiers.model}'])
+    model = load_model(inputs['{InputIdentifiers.shared}'])
 
     res = [x * model['value'] for x in X]
     print(f'Predict, get X: {{X}}, model: {{model}}, return {{res}}')
@@ -144,7 +144,7 @@ import substratools as tools
 def aggregate(inputs, outputs, task_properties):
     rank = task_properties['{InputIdentifiers.rank}']
     models = []
-    for m_path in inputs['{InputIdentifiers.models}']:
+    for m_path in inputs['{InputIdentifiers.shared}']:
         models.append(load_model(m_path))
 
     print(f'Aggregate models: {{models}}')
@@ -152,12 +152,12 @@ def aggregate(inputs, outputs, task_properties):
     avg = sum(values) / len(values)
     res = {{'value': avg}}
     print(f'Aggregate result: {{res}}')
-    save_model(res, outputs['{OutputIdentifiers.model}'])
+    save_model(res, outputs['{OutputIdentifiers.shared}'])
 
 @tools.register
 def predict(inputs, outputs, task_properties):
     X = inputs['{InputIdentifiers.datasamples}'][0]
-    model = load_model(inputs['{InputIdentifiers.model}'])
+    model = load_model(inputs['{InputIdentifiers.shared}'])
 
     res = [x * model['value'] for x in X]
     print(f'Predict, get X: {{X}}, model: {{model}}, return {{res}}')

--- a/substratest/fl_interface.py
+++ b/substratest/fl_interface.py
@@ -43,7 +43,7 @@ class FLFunctionInputs(list, Enum):
     """Substra function inputs by function category based on the InputIdentifiers"""
 
     FUNCTION_AGGREGATE = [
-        FunctionInputSpec(identifier=InputIdentifiers.models, kind=AssetKind.model.value, optional=False, multiple=True)
+        FunctionInputSpec(identifier=InputIdentifiers.shared, kind=AssetKind.model.value, optional=False, multiple=True)
     ]
     FUNCTION_SIMPLE = [
         FunctionInputSpec(
@@ -55,7 +55,7 @@ class FLFunctionInputs(list, Enum):
         FunctionInputSpec(
             identifier=InputIdentifiers.opener, kind=AssetKind.data_manager.value, optional=False, multiple=False
         ),
-        FunctionInputSpec(identifier=InputIdentifiers.models, kind=AssetKind.model.value, optional=True, multiple=True),
+        FunctionInputSpec(identifier=InputIdentifiers.shared, kind=AssetKind.model.value, optional=True, multiple=True),
     ]
     FUNCTION_COMPOSITE = [
         FunctionInputSpec(
@@ -83,7 +83,7 @@ class FLFunctionInputs(list, Enum):
             identifier=InputIdentifiers.opener, kind=AssetKind.data_manager.value, optional=False, multiple=False
         ),
         FunctionInputSpec(
-            identifier=InputIdentifiers.model, kind=AssetKind.model.value, optional=False, multiple=False
+            identifier=InputIdentifiers.shared, kind=AssetKind.model.value, optional=False, multiple=False
         ),
     ]
     FUNCTION_PREDICT_COMPOSITE = [
@@ -123,10 +123,10 @@ class FLFunctionOutputs(list, Enum):
     """Substra function outputs by function category based on the OutputIdentifiers"""
 
     FUNCTION_AGGREGATE = [
-        FunctionOutputSpec(identifier=OutputIdentifiers.model, kind=AssetKind.model.value, multiple=False)
+        FunctionOutputSpec(identifier=OutputIdentifiers.shared, kind=AssetKind.model.value, multiple=False)
     ]
     FUNCTION_SIMPLE = [
-        FunctionOutputSpec(identifier=OutputIdentifiers.model, kind=AssetKind.model.value, multiple=False)
+        FunctionOutputSpec(identifier=OutputIdentifiers.shared, kind=AssetKind.model.value, multiple=False)
     ]
     FUNCTION_COMPOSITE = [
         FunctionOutputSpec(identifier=OutputIdentifiers.local, kind=AssetKind.model.value, multiple=False),
@@ -166,9 +166,9 @@ class FLTaskInputGenerator:
     def trains_to_train(model_keys):
         return [
             InputRef(
-                identifier=InputIdentifiers.models,
+                identifier=InputIdentifiers.shared,
                 parent_task_key=model_key,
-                parent_task_output_identifier=OutputIdentifiers.model,
+                parent_task_output_identifier=OutputIdentifiers.shared,
             )
             for model_key in model_keys
         ]
@@ -177,9 +177,9 @@ class FLTaskInputGenerator:
     def trains_to_aggregate(model_keys):
         return [
             InputRef(
-                identifier=InputIdentifiers.models,
+                identifier=InputIdentifiers.shared,
                 parent_task_key=model_key,
-                parent_task_output_identifier=OutputIdentifiers.model,
+                parent_task_output_identifier=OutputIdentifiers.shared,
             )
             for model_key in model_keys
         ]
@@ -188,9 +188,9 @@ class FLTaskInputGenerator:
     def train_to_predict(model_key):
         return [
             InputRef(
-                identifier=InputIdentifiers.model,
+                identifier=InputIdentifiers.shared,
                 parent_task_key=model_key,
-                parent_task_output_identifier=OutputIdentifiers.model,
+                parent_task_output_identifier=OutputIdentifiers.shared,
             )
         ]
 
@@ -250,7 +250,7 @@ class FLTaskInputGenerator:
             InputRef(
                 identifier=InputIdentifiers.shared,
                 parent_task_key=model_key,
-                parent_task_output_identifier=OutputIdentifiers.model,
+                parent_task_output_identifier=OutputIdentifiers.shared,
             )
         ]
 
@@ -258,7 +258,7 @@ class FLTaskInputGenerator:
     def composites_to_aggregate(model_keys):
         return [
             InputRef(
-                identifier=InputIdentifiers.models,
+                identifier=InputIdentifiers.shared,
                 parent_task_key=model_key,
                 parent_task_output_identifier=OutputIdentifiers.shared,
             )
@@ -269,9 +269,9 @@ class FLTaskInputGenerator:
     def aggregate_to_predict(model_key):
         return [
             InputRef(
-                identifier=InputIdentifiers.model,
+                identifier=InputIdentifiers.shared,
                 parent_task_key=model_key,
-                parent_task_output_identifier=OutputIdentifiers.model,
+                parent_task_output_identifier=OutputIdentifiers.shared,
             )
         ]
 
@@ -279,7 +279,7 @@ class FLTaskInputGenerator:
     def local_to_aggregate(model_key):
         return [
             InputRef(
-                identifier=InputIdentifiers.models,
+                identifier=InputIdentifiers.shared,
                 parent_task_key=model_key,
                 parent_task_output_identifier=OutputIdentifiers.local,
             )
@@ -289,7 +289,7 @@ class FLTaskInputGenerator:
     def shared_to_aggregate(model_key):
         return [
             InputRef(
-                identifier=InputIdentifiers.models,
+                identifier=InputIdentifiers.shared,
                 parent_task_key=model_key,
                 parent_task_output_identifier=OutputIdentifiers.shared,
             )
@@ -309,14 +309,14 @@ class FLTaskOutputGenerator:
     @staticmethod
     def traintask(authorized_ids=None, transient=False):
         return {
-            OutputIdentifiers.model: ComputeTaskOutputSpec(
+            OutputIdentifiers.shared: ComputeTaskOutputSpec(
                 permissions=_permission_from_ids(authorized_ids), transient=transient
             )
         }
 
     @staticmethod
     def aggregatetask(authorized_ids=None):
-        return {OutputIdentifiers.model: ComputeTaskOutputSpec(permissions=_permission_from_ids(authorized_ids))}
+        return {OutputIdentifiers.shared: ComputeTaskOutputSpec(permissions=_permission_from_ids(authorized_ids))}
 
     @staticmethod
     def predicttask(authorized_ids=None):

--- a/substratest/fl_interface.py
+++ b/substratest/fl_interface.py
@@ -22,8 +22,6 @@ class FunctionCategory(str, Enum):
 class InputIdentifiers(str, Enum):
     local = "local"
     shared = "shared"
-    model = "model"
-    models = "models"
     predictions = "predictions"
     performance = "performance"
     opener = "opener"
@@ -34,7 +32,6 @@ class InputIdentifiers(str, Enum):
 class OutputIdentifiers(str, Enum):
     local = "local"
     shared = "shared"
-    model = "model"
     predictions = "predictions"
     performance = "performance"
 

--- a/tests/test_data_samples_order.py
+++ b/tests/test_data_samples_order.py
@@ -27,21 +27,21 @@ import substratools as tools
 def train(inputs, outputs, task_properties):
 
     models = []
-    for m_path in inputs.get('{InputIdentifiers.models}', []):
+    for m_path in inputs.get('{InputIdentifiers.shared}', []):
         models.append(load_model(m_path))
 
     # Check that the order of X is the same as the one passed to add_task
     datasample_keys = [d.split("/")[-1] for d in inputs['{InputIdentifiers.datasamples}']]
     assert datasample_keys == {{data_sample_keys}}, datasample_keys
 
-    save_model(([0, 1], [0, 2]), outputs['{OutputIdentifiers.model}'])
+    save_model(([0, 1], [0, 2]), outputs['{OutputIdentifiers.shared}'])
 
 @tools.register
 def predict(inputs, outputs, task_properties):
     # Check that the order of X is the same as the one passed to add_task
     datasamples = inputs['{InputIdentifiers.datasamples}']
     datasample_keys = [d.split("/")[-1] for d in datasamples]
-    model = load_model(inputs['{InputIdentifiers.model}'])
+    model = load_model(inputs['{InputIdentifiers.shared}'])
     assert datasample_keys == {{test_data_sample_keys}}, datasample_keys
     save_predictions(datasamples, outputs['{OutputIdentifiers.predictions}'])
 
@@ -322,7 +322,7 @@ def train(inputs, outputs, task_properties):
 
     datasamples = inputs['{InputIdentifiers.datasamples}']
     assert datasamples == list(range({batch_size})), datasamples
-    save_model(0, outputs['{OutputIdentifiers.model}'])
+    save_model(0, outputs['{OutputIdentifiers.shared}'])
 
 @tools.register
 def predict(inputs, outputs, task_properties):

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -966,7 +966,7 @@ def train(inputs, outputs, task_properties):
 @tools.register
 def predict(inputs, outputs, task_properties):
     X = inputs['{InputIdentifiers.datasamples}'][0]
-    model = load_model(inputs['{InputIdentifiers.model}'])
+    model = load_model(inputs['{InputIdentifiers.shared}'])
 
     res = [x * model['value'] for x in X]
     print(f'Predict, get X: {{X}}, model: {{model}}, return {{res}}')

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -44,7 +44,7 @@ def test_tasks_execution_on_same_organization(factory, network, client, default_
     assert traintask.metadata == {"foo": "bar"}
     assert len(traintask.outputs) == 1
     # Raises an exception if the output asset have not been created
-    output = client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+    output = client.get_task_output_asset(traintask.key, OutputIdentifiers.shared)
 
     if network.options.enable_model_download:
         model = output.asset
@@ -175,7 +175,7 @@ def test_tasks_execution_on_different_organizations(
     assert traintask.error_type is None
     assert len(traintask.outputs) == 1
     # Raises an exception if the output asset have not been created
-    client_1.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+    client_1.get_task_output_asset(traintask.key, OutputIdentifiers.shared)
     assert traintask.worker == client_2.organization_id
 
     # add testtask; should execute on organization 1 (default_dataset_1 is located on organization 1)
@@ -228,7 +228,7 @@ def test_function_build_failure(factory, network, default_dataset_1, worker):
         assert traintask.status == Status.failed
         assert traintask.error_type == substra.sdk.models.TaskErrorType.build
         with pytest.raises(TaskAssetNotFoundError):
-            network.clients[0].get_task_output_asset(traintask.key, OutputIdentifiers.model)
+            network.clients[0].get_task_output_asset(traintask.key, OutputIdentifiers.shared)
 
         for client in (network.clients[0], network.clients[1]):
             logs = client.download_logs(traintask.key)
@@ -255,7 +255,7 @@ def test_task_execution_failure(factory, network, default_dataset_1, worker):
         assert traintask.status == Status.failed
         assert traintask.error_type == substra.sdk.models.TaskErrorType.execution
         with pytest.raises(TaskAssetNotFoundError):
-            network.clients[0].get_task_output_asset(traintask.key, OutputIdentifiers.model)
+            network.clients[0].get_task_output_asset(traintask.key, OutputIdentifiers.shared)
 
         for client in (network.clients[0], network.clients[1]):
             logs = client.download_logs(traintask.key)
@@ -419,7 +419,7 @@ def test_aggregatetask_execution_failure(factory, client, default_dataset, worke
         assert aggregatetask.status == Status.failed
         assert aggregatetask.error_type == substra.sdk.models.TaskErrorType.execution
         with pytest.raises(TaskAssetNotFoundError):
-            client.get_task_output_asset(aggregatetask.key, OutputIdentifiers.model)
+            client.get_task_output_asset(aggregatetask.key, OutputIdentifiers.shared)
         assert "Traceback (most recent call last):" in client.download_logs(aggregatetask.key)
 
     elif client.backend_mode in (substra.BackendType.LOCAL_SUBPROCESS, substra.BackendType.LOCAL_DOCKER):
@@ -527,7 +527,7 @@ def test_aggregatetask(factory, client, default_metric, default_dataset, worker)
     )
     aggregatetask = client.add_task(spec)
     assert (
-        len([i for i in aggregatetask.inputs if i.identifier == InputIdentifiers.models])
+        len([i for i in aggregatetask.inputs if i.identifier == InputIdentifiers.shared])
         == number_of_traintasks_to_aggregate
     )
 
@@ -579,7 +579,7 @@ def test_aggregatetask_chained(factory, client, default_dataset, worker):
 
     aggregatetask_1 = client.add_task(spec)
     assert (
-        len([i for i in aggregatetask_1.inputs if i.identifier == InputIdentifiers.models])
+        len([i for i in aggregatetask_1.inputs if i.identifier == InputIdentifiers.shared])
         == number_of_traintasks_to_aggregate
     )
 
@@ -594,7 +594,7 @@ def test_aggregatetask_chained(factory, client, default_dataset, worker):
     aggregatetask_2 = client.wait_task(aggregatetask_2.key)
     assert aggregatetask_2.status == Status.done
     assert aggregatetask_2.error_type is None
-    assert len([i for i in aggregatetask_2.inputs if i.identifier == InputIdentifiers.models]) == 1
+    assert len([i for i in aggregatetask_2.inputs if i.identifier == InputIdentifiers.shared]) == 1
 
 
 @pytest.mark.slow
@@ -628,7 +628,7 @@ def test_aggregatetask_traintask(factory, client, default_dataset, worker):
         inputs=FLTaskInputGenerator.trains_to_aggregate([traintask_1.key]),
     )
     aggregatetask = client.add_task(spec)
-    assert len([i for i in aggregatetask.inputs if i.identifier == InputIdentifiers.models]) == 1
+    assert len([i for i in aggregatetask.inputs if i.identifier == InputIdentifiers.shared]) == 1
 
     # add second part of the traintasks
     spec = factory.create_traintask(
@@ -878,7 +878,7 @@ def test_use_data_sample_located_in_shared_path(factory, network, client, organi
     assert traintask.error_type is None
 
     # Raises an exception if the output asset have not been created
-    client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+    client.get_task_output_asset(traintask.key, OutputIdentifiers.shared)
 
     # create testtask
     spec = factory.create_predicttask(
@@ -920,7 +920,7 @@ def train(inputs, outputs, task_properties):
     assert model_path.is_file()
     loaded = json.loads(model_path.read_text())
     assert loaded == {{'name':'Jane'}}
-    save_model(dict(), outputs['{OutputIdentifiers.model}'])
+    save_model(dict(), outputs['{OutputIdentifiers.shared}'])
 
 
 @tools.register
@@ -961,7 +961,7 @@ def train(inputs, outputs, task_properties):
     with open(f"{{str(Path.home())}}/foo", "w") as f:
         f.write("test")
 
-    save_model({{'value': 42 }}, outputs['{OutputIdentifiers.model}'])
+    save_model({{'value': 42 }}, outputs['{OutputIdentifiers.shared}'])
 
 @tools.register
 def predict(inputs, outputs, task_properties):

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -107,7 +107,7 @@ def test_compute_plan_simple(
     traintask_2 = [t for t in full_tasks if t.key == traintask_spec_2.task_id][0]
     traintask_3 = [t for t in full_tasks if t.key == traintask_spec_3.task_id][0]
 
-    assert len([i for i in traintask_3.inputs if i.identifier == InputIdentifiers.models]) == 2
+    assert len([i for i in traintask_3.inputs if i.identifier == InputIdentifiers.shared]) == 2
 
     predicttask = [t for t in full_tasks if t.key == predicttask_spec_3.task_id][0]
     testtask = [t for t in full_tasks if t.key == testtask_spec.task_id][0]
@@ -573,7 +573,7 @@ def test_compute_plan_aggregate_composite_traintasks(  # noqa: C901
                         if i.identifier == InputIdentifiers.shared
                         and i.parent_task_key
                         == [x for x in task.inputs if x.identifier == InputIdentifiers.shared][0].parent_task_key
-                        and i.parent_task_output_identifier == OutputIdentifiers.model
+                        and i.parent_task_output_identifier == OutputIdentifiers.shared
                     ]
                 )
                 == 1
@@ -733,7 +733,7 @@ def test_compute_plan_transient_outputs(factory: AssetsFactory, client: Client, 
     client.wait_compute_plan(cp_added.key)
 
     traintask_1 = client.get_task(traintask_spec_1.task_id)
-    assert traintask_1.outputs[OutputIdentifiers.model].is_transient is True
+    assert traintask_1.outputs[OutputIdentifiers.shared].is_transient is True
 
     # Validate that the transient model is properly deleted
     model = client.get_task_models(traintask_spec_1.task_id)[0]

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -27,7 +27,7 @@ import torch
 @tools.register
 def train(inputs, outputs, task_properties):
     assert torch.cuda.is_available()
-    save_model(['test'], outputs['{OutputIdentifiers.model}'])
+    save_model(['test'], outputs['{OutputIdentifiers.shared}'])
 
 @tools.register
 def predict(X, model):

--- a/tests/test_hybrid_mode.py
+++ b/tests/test_hybrid_mode.py
@@ -41,7 +41,7 @@ def test_execution_debug(client, hybrid_client, debug_factory, default_dataset):
     assert traintask.status == models.Status.done
 
     # Raises an exception if the output asset have not been created
-    hybrid_client.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+    hybrid_client.get_task_output_asset(traintask.key, OutputIdentifiers.shared)
 
     # Add the testtask
     spec = debug_factory.create_predicttask(

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -174,12 +174,12 @@ def test_permissions(permissions_1, permissions_2, expected_permissions, factory
 
     # check the compute task executed on the correct worker
     # Raises an exception if the output asset have not been created
-    client_1.get_task_output_asset(traintask.key, OutputIdentifiers.model)
+    client_1.get_task_output_asset(traintask.key, OutputIdentifiers.shared)
 
     assert traintask.worker == client_1.organization_id
 
     # check the permissions
-    task_permissions = traintask.outputs[OutputIdentifiers.model].permissions
+    task_permissions = traintask.outputs[OutputIdentifiers.shared].permissions
     assert task_permissions.process.public == expected_permissions.public
     assert set(task_permissions.process.authorized_ids) == set(expected_permissions.authorized_ids)
 
@@ -270,8 +270,8 @@ def test_permissions_model_process(
     traintask_1 = client_1.add_task(spec)
     traintask_1 = client_1.wait_task(traintask_1.key)
 
-    assert not traintask_1.outputs[OutputIdentifiers.model].permissions.process.public
-    assert set(traintask_1.outputs[OutputIdentifiers.model].permissions.process.authorized_ids) == set(
+    assert not traintask_1.outputs[OutputIdentifiers.shared].permissions.process.public
+    assert set(traintask_1.outputs[OutputIdentifiers.shared].permissions.process.authorized_ids) == set(
         [client_1.organization_id] + client_1_permissions.authorized_ids
     )
 

--- a/tests/workflows/mnist-fedavg/assets/aggregate_function.py
+++ b/tests/workflows/mnist-fedavg/assets/aggregate_function.py
@@ -1,5 +1,7 @@
 import os
 import shutil
+from substratest.fl_interface import InputIdentifiers
+from substratest.fl_interface import OutputIdentifiers
 
 import numpy as np
 import substratools as tools
@@ -34,7 +36,7 @@ Function that aggregates models by simply averaging them as in FedAvg
 def aggregate(inputs, outputs, task_properties):
     # get layers
     inmodels = []
-    for m_path in inputs["models"]:
+    for m_path in inputs[InputIdentifiers.shared]:
         inmodels.append(load_model(m_path))
 
     model = inmodels[0]
@@ -50,15 +52,15 @@ def aggregate(inputs, outputs, task_properties):
 
     model.load_state_dict(model_state_dict)
 
-    save_model(model, outputs["model"])
+    save_model(model, outputs[InputIdentifiers.shared])
 
 
 @tools.register
 def predict(inputs, outputs, task_properties):
-    X = inputs["datasamples"]["X"]
+    X = inputs[InputIdentifiers.datasamples]["X"]
     X = torch.FloatTensor(X)
 
-    model = load_model(inputs["models"])
+    model = load_model(inputs[InputIdentifiers.shared])
     model.eval()
     # add the context manager to reduce computation overhead
     with torch.no_grad():
@@ -67,7 +69,7 @@ def predict(inputs, outputs, task_properties):
     y_pred = y_pred.data.cpu().numpy()
     pred = np.argmax(y_pred, axis=1)
 
-    save_predictions(pred, outputs["predictions"])
+    save_predictions(pred, outputs[OutputIdentifiers.predictions])
 
 
 def load_model(path):

--- a/tests/workflows/mnist-fedavg/assets/aggregate_function.py
+++ b/tests/workflows/mnist-fedavg/assets/aggregate_function.py
@@ -34,7 +34,7 @@ Function that aggregates models by simply averaging them as in FedAvg
 def aggregate(inputs, outputs, task_properties):
     # get layers
     inmodels = []
-    for m_path in inputs["models"]:
+    for m_path in inputs["shared"]:
         inmodels.append(load_model(m_path))
 
     model = inmodels[0]

--- a/tests/workflows/mnist-fedavg/assets/aggregate_function.py
+++ b/tests/workflows/mnist-fedavg/assets/aggregate_function.py
@@ -6,9 +6,6 @@ import substratools as tools
 import torch
 import torch.nn.functional as F
 
-from substratest.fl_interface import InputIdentifiers
-from substratest.fl_interface import OutputIdentifiers
-
 _INPUT_SAMPLE_SIZE = 21632
 _OUT_SAMPLE_SIZE = 10
 _NB_CHANNELS = 32
@@ -37,7 +34,7 @@ Function that aggregates models by simply averaging them as in FedAvg
 def aggregate(inputs, outputs, task_properties):
     # get layers
     inmodels = []
-    for m_path in inputs[InputIdentifiers.shared]:
+    for m_path in inputs["models"]:
         inmodels.append(load_model(m_path))
 
     model = inmodels[0]
@@ -53,15 +50,15 @@ def aggregate(inputs, outputs, task_properties):
 
     model.load_state_dict(model_state_dict)
 
-    save_model(model, outputs[InputIdentifiers.shared])
+    save_model(model, outputs["shared"])
 
 
 @tools.register
 def predict(inputs, outputs, task_properties):
-    X = inputs[InputIdentifiers.datasamples]["X"]
+    X = inputs["datasamples"]["X"]
     X = torch.FloatTensor(X)
 
-    model = load_model(inputs[InputIdentifiers.shared])
+    model = load_model(inputs["shared"])
     model.eval()
     # add the context manager to reduce computation overhead
     with torch.no_grad():
@@ -70,7 +67,7 @@ def predict(inputs, outputs, task_properties):
     y_pred = y_pred.data.cpu().numpy()
     pred = np.argmax(y_pred, axis=1)
 
-    save_predictions(pred, outputs[OutputIdentifiers.predictions])
+    save_predictions(pred, outputs["predictions"])
 
 
 def load_model(path):

--- a/tests/workflows/mnist-fedavg/assets/aggregate_function.py
+++ b/tests/workflows/mnist-fedavg/assets/aggregate_function.py
@@ -1,12 +1,13 @@
 import os
 import shutil
-from substratest.fl_interface import InputIdentifiers
-from substratest.fl_interface import OutputIdentifiers
 
 import numpy as np
 import substratools as tools
 import torch
 import torch.nn.functional as F
+
+from substratest.fl_interface import InputIdentifiers
+from substratest.fl_interface import OutputIdentifiers
 
 _INPUT_SAMPLE_SIZE = 21632
 _OUT_SAMPLE_SIZE = 10

--- a/tests/workflows/mnist-fedavg/assets/composite_function.py
+++ b/tests/workflows/mnist-fedavg/assets/composite_function.py
@@ -6,9 +6,6 @@ import substratools as tools
 import torch
 import torch.nn.functional as F
 
-from substratest.fl_interface import InputIdentifiers
-from substratest.fl_interface import OutputIdentifiers
-
 _INPUT_SAMPLE_SIZE = 21632
 _OUT_SAMPLE_SIZE = 10
 _NB_CHANNELS = 32
@@ -67,14 +64,14 @@ def train(inputs, outputs, task_properties):
     torch.manual_seed(_SEED)  # initialize model weights
     torch.use_deterministic_algorithms(True)
 
-    head_model_path = inputs.get(InputIdentifiers.local)
-    trunk_model_path = inputs.get(InputIdentifiers.shared)
+    head_model_path = inputs.get("local")
+    trunk_model_path = inputs.get("shared")
 
     head_model = load_head_model(head_model_path) if head_model_path is not None else torch.nn.Module()
     trunk_model = load_trunk_model(trunk_model_path) if trunk_model_path is not None else Network()
 
-    X = inputs[InputIdentifiers.datasamples]["X"]
-    y = inputs[InputIdentifiers.datasamples]["y"]
+    X = inputs["datasamples"]["X"]
+    y = inputs["datasamples"]["y"]
     rank = task_properties["rank"]
 
     _fit(
@@ -86,15 +83,15 @@ def train(inputs, outputs, task_properties):
         rank=rank,
     )
 
-    save_head_model(head_model, outputs[OutputIdentifiers.local])
-    save_trunk_model(trunk_model, outputs[OutputIdentifiers.shared])
+    save_head_model(head_model, outputs["local"])
+    save_trunk_model(trunk_model, outputs["shared"])
 
 
 @tools.register
 def predict(inputs, outputs, task_properties):
-    trunk_model = load_trunk_model(inputs[OutputIdentifiers.shared])
+    trunk_model = load_trunk_model(inputs["shared"])
 
-    X = inputs[InputIdentifiers.datasamples]["X"]
+    X = inputs["datasamples"]["X"]
     X = torch.FloatTensor(X)
     trunk_model.eval()
 
@@ -105,7 +102,7 @@ def predict(inputs, outputs, task_properties):
     y_pred = y_pred.data.cpu().numpy()
     pred = np.argmax(y_pred, axis=1)
 
-    save_predictions(pred, outputs[OutputIdentifiers.predictions])
+    save_predictions(pred, outputs["predictions"])
 
 
 def load_model(path):

--- a/tests/workflows/mnist-fedavg/assets/composite_function.py
+++ b/tests/workflows/mnist-fedavg/assets/composite_function.py
@@ -1,5 +1,7 @@
 import os
 import shutil
+from substratest.fl_interface import InputIdentifiers
+from substratest.fl_interface import OutputIdentifiers
 
 import numpy as np
 import substratools as tools
@@ -64,14 +66,14 @@ def train(inputs, outputs, task_properties):
     torch.manual_seed(_SEED)  # initialize model weights
     torch.use_deterministic_algorithms(True)
 
-    head_model_path = inputs.get("local")
-    trunk_model_path = inputs.get("shared")
+    head_model_path = inputs.get(InputIdentifiers.local)
+    trunk_model_path = inputs.get(InputIdentifiers.shared)
 
     head_model = load_head_model(head_model_path) if head_model_path is not None else torch.nn.Module()
     trunk_model = load_trunk_model(trunk_model_path) if trunk_model_path is not None else Network()
 
-    X = inputs["datasamples"]["X"]
-    y = inputs["datasamples"]["y"]
+    X = inputs[InputIdentifiers.datasamples]["X"]
+    y = inputs[InputIdentifiers.datasamples]["y"]
     rank = task_properties["rank"]
 
     _fit(
@@ -83,15 +85,15 @@ def train(inputs, outputs, task_properties):
         rank=rank,
     )
 
-    save_head_model(head_model, outputs["local"])
-    save_trunk_model(trunk_model, outputs["shared"])
+    save_head_model(head_model, outputs[OutputIdentifiers.local])
+    save_trunk_model(trunk_model, outputs[OutputIdentifiers.shared])
 
 
 @tools.register
 def predict(inputs, outputs, task_properties):
-    trunk_model = load_trunk_model(inputs["shared"])
+    trunk_model = load_trunk_model(inputs[OutputIdentifiers.shared])
 
-    X = inputs["datasamples"]["X"]
+    X = inputs[InputIdentifiers.datasamples]["X"]
     X = torch.FloatTensor(X)
     trunk_model.eval()
 
@@ -102,7 +104,7 @@ def predict(inputs, outputs, task_properties):
     y_pred = y_pred.data.cpu().numpy()
     pred = np.argmax(y_pred, axis=1)
 
-    save_predictions(pred, outputs["predictions"])
+    save_predictions(pred, outputs[OutputIdentifiers.predictions])
 
 
 def load_model(path):

--- a/tests/workflows/mnist-fedavg/assets/composite_function.py
+++ b/tests/workflows/mnist-fedavg/assets/composite_function.py
@@ -1,12 +1,13 @@
 import os
 import shutil
-from substratest.fl_interface import InputIdentifiers
-from substratest.fl_interface import OutputIdentifiers
 
 import numpy as np
 import substratools as tools
 import torch
 import torch.nn.functional as F
+
+from substratest.fl_interface import InputIdentifiers
+from substratest.fl_interface import OutputIdentifiers
 
 _INPUT_SAMPLE_SIZE = 21632
 _OUT_SAMPLE_SIZE = 10


### PR DESCRIPTION
## Summary

Remove models and model to input and output identifier to put only `shared_state`. This change help to improve the flexibility on workflows. In particular, it unlock the possibility to link train tasks with each other (needde in cyclic strategy for instance).

## Companion PR

- https://github.com/Substra/substrafl/pull/142 (main)
- https://github.com/Substra/substra/pull/367
- https://github.com/Substra/substra-tools/pull/84
- https://github.com/Substra/substra-tests/pull/261