### PR TITLE
chore: release 0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.0] - 2023-06-27
+
 ### Changed
  - Define test client (`substratest.client.Client`) as child class of `substra.Client` (#205)
 ([#257](https://github.com/Substra/substra-tests/pull/257))


### PR DESCRIPTION
## [0.42.0] - 2023-06-27

### Changed
 - Define test client (`substratest.client.Client`) as child class of `substra.Client` (#205)
([#257](https://github.com/Substra/substra-tests/pull/257))