### PR TITLE
chore: centralize wait task in substrasdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  - Define test client (`substratest.client.Client`) as child class of `substra.Client` (#205)
 ([#257](https://github.com/Substra/substra-tests/pull/257))
+- Moved `wait_task` and `wait_compute_task` from `substratest.client.Client` to `substra.Client` ([#263](https://github.com/Substra/substra-tests/pull/263))
 
 ## [0.41.0] - 2023-06-12
 

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -141,7 +141,7 @@ class Client(substra.Client):
         return getter(asset.key)
 
     # Dismiss `polling_period`
-    def _wait(self, *, timeout=None, polling_period, **kwargs):
+    def _wait(self, *, polling_period, timeout=None, **kwargs):
         timeout = timeout or self.future_timeout
         return super()._wait(timeout=timeout, polling_period=self.future_polling_period, **kwargs)
 

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -140,7 +140,8 @@ class Client(substra.Client):
 
         return getter(asset.key)
 
-    def _wait(self, *, timeout=None, **kwargs):
+    # Dismiss `polling_period`
+    def _wait(self, *, timeout=None, polling_period, **kwargs):
         timeout = timeout or self.future_timeout
         return super()._wait(timeout=timeout, polling_period=self.future_polling_period, **kwargs)
 

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -142,7 +142,7 @@ class Client(substra.Client):
 
     def _wait(self, *, timeout=None, **kwargs):
         timeout = timeout or self.future_timeout
-        return super().wait(timeout=timeout, polling_period=self.future_polling_period, **kwargs)
+        return super()._wait(timeout=timeout, polling_period=self.future_polling_period, **kwargs)
 
     def wait_model_deletion(self, model_key):
         """Wait for the model to be deleted (address unset)"""

--- a/substratest/errors.py
+++ b/substratest/errors.py
@@ -1,4 +1,4 @@
-from substra.exception import FutureError
+from substra.sdk.exceptions import FutureError
 
 
 class SynchronizationTimeoutError(FutureError):

--- a/substratest/errors.py
+++ b/substratest/errors.py
@@ -1,14 +1,5 @@
-class TError(Exception):
-    """Substra Test Error."""
+from substra.exception import FutureError
 
 
-class FutureTimeoutError(TError):
-    """Future execution timed out."""
-
-
-class FutureFailureError(TError):
-    """Future execution failed."""
-
-
-class SynchronizationTimeoutError(TError):
+class SynchronizationTimeoutError(FutureError):
     """Asset could not be synchronized inn time."""

--- a/tests/test_data_samples_order.py
+++ b/tests/test_data_samples_order.py
@@ -208,7 +208,7 @@ def test_task_data_samples_relative_order(factory, client, dataset, worker):
         i.asset_key for i in traintask.inputs if i.identifier == InputIdentifiers.datasamples
     ] == dataset.train_data_sample_keys
     # `raises = True`, will fail if task not successful
-    client.wait_task(traintask.key, raises=True)
+    client.wait_task(traintask.key, raise_on_failure=True)
 
     predict_input_models = FLTaskInputGenerator.train_to_predict(traintask.key)
     predicttask_spec = factory.create_predicttask(
@@ -225,7 +225,7 @@ def test_task_data_samples_relative_order(factory, client, dataset, worker):
 
     # Assert order is correct in the metric. If not, wait_task() will fail.
     # `raises = True`, will fail if task not successful
-    client.wait_task(testtask.key, raises=True)
+    client.wait_task(testtask.key, raise_on_failure=True)
 
 
 def test_composite_traintask_data_samples_relative_order(factory, client, dataset, worker):
@@ -265,7 +265,7 @@ def test_composite_traintask_data_samples_relative_order(factory, client, datase
         i.asset_key for i in composite_traintask.inputs if i.identifier == InputIdentifiers.datasamples
     ] == dataset.train_data_sample_keys
     # `raises = True`, will fail if task not successful
-    client.wait_task(composite_traintask.key, raises=True)
+    client.wait_task(composite_traintask.key, raise_on_failure=True)
 
     predict_input_models = FLTaskInputGenerator.composite_to_predict(composite_traintask.key)
 
@@ -283,7 +283,7 @@ def test_composite_traintask_data_samples_relative_order(factory, client, datase
 
     # Assert order is correct in the metric. If not, _wait() will fail.
     # `raises = True`, will fail if task not successful
-    client.wait_task(testtask.key, raises=True)
+    client.wait_task(testtask.key, raise_on_failure=True)
 
 
 @pytest.mark.slow
@@ -357,4 +357,4 @@ if __name__ == '__main__':
     traintask = client.add_task(spec)
 
     # `raises = True`, will fail if task not successful
-    client.wait_task(traintask.key, raises=True)
+    client.wait_task(traintask.key, raise_on_failure=True)

--- a/tests/test_data_samples_order.py
+++ b/tests/test_data_samples_order.py
@@ -1,5 +1,4 @@
 import pytest
-from substra.sdk.models import Status
 
 import substratest as sbt
 from substratest.factory import DEFAULT_DATA_SAMPLE_FILENAME
@@ -208,7 +207,8 @@ def test_task_data_samples_relative_order(factory, client, dataset, worker):
     assert [
         i.asset_key for i in traintask.inputs if i.identifier == InputIdentifiers.datasamples
     ] == dataset.train_data_sample_keys
-    client.wait_task(traintask.key)
+    # `raises = True`, will fail if task not successful
+    client.wait_task(traintask.key, raises=True)
 
     predict_input_models = FLTaskInputGenerator.train_to_predict(traintask.key)
     predicttask_spec = factory.create_predicttask(
@@ -224,7 +224,8 @@ def test_task_data_samples_relative_order(factory, client, dataset, worker):
     testtask = client.add_task(testtask_spec)
 
     # Assert order is correct in the metric. If not, wait_task() will fail.
-    client.wait_task(testtask.key)
+    # `raises = True`, will fail if task not successful
+    client.wait_task(testtask.key, raises=True)
 
 
 def test_composite_traintask_data_samples_relative_order(factory, client, dataset, worker):
@@ -263,7 +264,8 @@ def test_composite_traintask_data_samples_relative_order(factory, client, datase
     assert [
         i.asset_key for i in composite_traintask.inputs if i.identifier == InputIdentifiers.datasamples
     ] == dataset.train_data_sample_keys
-    client.wait_task(composite_traintask.key)
+    # `raises = True`, will fail if task not successful
+    client.wait_task(composite_traintask.key, raises=True)
 
     predict_input_models = FLTaskInputGenerator.composite_to_predict(composite_traintask.key)
 
@@ -280,7 +282,8 @@ def test_composite_traintask_data_samples_relative_order(factory, client, datase
     testtask = client.add_task(testtask_spec)
 
     # Assert order is correct in the metric. If not, _wait() will fail.
-    client.wait_task(testtask.key)
+    # `raises = True`, will fail if task not successful
+    client.wait_task(testtask.key, raises=True)
 
 
 @pytest.mark.slow
@@ -352,5 +355,6 @@ if __name__ == '__main__':
         worker=worker,
     )
     traintask = client.add_task(spec)
-    traintask = client.wait_task(traintask.key)
-    assert traintask.status == Status.done
+
+    # `raises = True`, will fail if task not successful
+    client.wait_task(traintask.key, raises=True)

--- a/tests/test_docker_image_build.py
+++ b/tests/test_docker_image_build.py
@@ -32,4 +32,4 @@ ENTRYPOINT ["python3", "function.py", "--function-name", "{DEFAULT_FUNCTION_NAME
     )
     traintask = client.add_task(spec)
     # `raises = True`, will fail if task not successful
-    client.wait_task(traintask.key, raises=True)
+    client.wait_task(traintask.key, raise_on_failure=True)

--- a/tests/test_docker_image_build.py
+++ b/tests/test_docker_image_build.py
@@ -31,4 +31,5 @@ ENTRYPOINT ["python3", "function.py", "--function-name", "{DEFAULT_FUNCTION_NAME
         worker=worker,
     )
     traintask = client.add_task(spec)
-    traintask = client.wait_task(traintask.key)
+    # `raises = True`, will fail if task not successful
+    client.wait_task(traintask.key, raises=True)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -38,7 +38,7 @@ def test_tasks_execution_on_same_organization(factory, network, client, default_
 
     spec = get_traintask_spec()
     traintask = client.add_task(spec)
-    traintask = client.wait_task(traintask.key, raises=True)
+    traintask = client.wait_task(traintask.key, raise_on_failure=True)
     assert traintask.error_type is None
     assert traintask.metadata == {"foo": "bar"}
     assert len(traintask.outputs) == 1
@@ -62,7 +62,7 @@ def test_tasks_execution_on_same_organization(factory, network, client, default_
 
     predicttask = client.add_task(spec)
     # `raises = True`, will fail if task not successful
-    predicttask = client.wait_task(predicttask.key, raises=True)
+    predicttask = client.wait_task(predicttask.key, raise_on_failure=True)
     assert predicttask.error_type is None
 
     spec = factory.create_testtask(
@@ -72,7 +72,7 @@ def test_tasks_execution_on_same_organization(factory, network, client, default_
     )
     testtask = client.add_task(spec)
     # `raises = True`, will fail if task not successful
-    testtask = client.wait_task(testtask.key, raises=True)
+    testtask = client.wait_task(testtask.key, raise_on_failure=True)
     assert testtask.error_type is None
     performance = client.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
     assert performance.asset == pytest.approx(2)
@@ -87,7 +87,7 @@ def test_tasks_execution_on_same_organization(factory, network, client, default_
     )
     traintask = client.add_task(spec)
     # `raises = True`, will fail if task not successful
-    traintask = client.wait_task(traintask.key, raises=True)
+    traintask = client.wait_task(traintask.key, raise_on_failure=True)
     assert testtask.error_type is None
     assert traintask.metadata == {}
 
@@ -122,7 +122,7 @@ def test_federated_learning_workflow(factory, client, default_datasets, workers)
             worker=workers[index],
         )
         traintask = client.add_task(spec)
-        traintask = client.wait_task(traintask.key, raises=True)
+        traintask = client.wait_task(traintask.key, raise_on_failure=True)
         out_models = client.get_task_models(traintask.key)
         assert traintask.error_type is None
         assert len(traintask.outputs) == 1
@@ -169,7 +169,7 @@ def test_tasks_execution_on_different_organizations(
     )
     traintask = client_1.add_task(spec)
     # `raises = True`, will fail if task not successful
-    traintask = client_1.wait_task(traintask.key, raises=True)
+    traintask = client_1.wait_task(traintask.key, raise_on_failure=True)
     assert traintask.error_type is None
     assert len(traintask.outputs) == 1
     # Raises an exception if the output asset have not been created
@@ -184,7 +184,7 @@ def test_tasks_execution_on_different_organizations(
     )
     predicttask = client_1.add_task(spec)
     # `raises = True`, will fail if task not successful
-    predicttask = client_1.wait_task(predicttask.key, raises=True)
+    predicttask = client_1.wait_task(predicttask.key, raise_on_failure=True)
     assert predicttask.error_type is None
     assert predicttask.worker == client_1.organization_id
 
@@ -195,7 +195,7 @@ def test_tasks_execution_on_different_organizations(
     )
     testtask = client_1.add_task(spec)
     # `raises = True`, will fail if task not successful
-    testtask = client_1.wait_task(testtask.key, raises=True)
+    testtask = client_1.wait_task(testtask.key, raise_on_failure=True)
     assert testtask.error_type is None
     assert testtask.worker == client_1.organization_id
     performance = client_2.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
@@ -221,7 +221,7 @@ def test_function_build_failure(factory, network, default_dataset_1, worker):
             network.clients[0].add_task(spec)
     else:
         traintask = network.clients[0].add_task(spec)
-        traintask = network.clients[0].wait_task(traintask.key, raises=False)
+        traintask = network.clients[0].wait_task(traintask.key, raise_on_failure=False)
 
         assert traintask.status == Status.failed
         assert traintask.error_type == substra.sdk.models.TaskErrorType.build
@@ -248,7 +248,7 @@ def test_task_execution_failure(factory, network, default_dataset_1, worker):
             network.clients[0].add_task(spec)
     else:
         traintask = network.clients[0].add_task(spec)
-        traintask = network.clients[0].wait_task(traintask.key, raises=False)
+        traintask = network.clients[0].wait_task(traintask.key, raise_on_failure=False)
 
         assert traintask.status == Status.failed
         assert traintask.error_type == substra.sdk.models.TaskErrorType.execution
@@ -296,7 +296,7 @@ if __name__ == '__main__':
     )
     traintask = client.add_task(spec)
     # `raises = True`, will fail if task not successful
-    traintask = client.wait_task(traintask.key, raises=True)
+    traintask = client.wait_task(traintask.key, raise_on_failure=True)
 
     # add predicttask
     spec = factory.create_predicttask(
@@ -306,7 +306,7 @@ if __name__ == '__main__':
     )
     predicttask = client.add_task(spec)
     # `raises = True`, will fail if task not successful
-    predicttask = client.wait_task(predicttask.key, raises=True)
+    predicttask = client.wait_task(predicttask.key, raise_on_failure=True)
 
     # add metric function
     spec = factory.create_function(category=FunctionCategory.metric, py_script=custom_metric_script)
@@ -329,7 +329,7 @@ if __name__ == '__main__':
 
     testtask = client.add_task(spec)
     # `raises = True`, will fail if task not successful
-    testtask = client.wait_task(testtask.key, raises=True)
+    testtask = client.wait_task(testtask.key, raise_on_failure=True)
     assert testtask.error_type is None
     output_1 = client.get_task_output_asset(testtask.key, identifier_1)
     output_2 = client.get_task_output_asset(testtask.key, identifier_2)
@@ -363,7 +363,7 @@ def test_composite_traintask_execution_failure(factory, client, default_dataset,
     )
     if client.backend_mode == substra.BackendType.REMOTE:
         composite_traintask = client.add_task(spec)
-        composite_traintask = client.wait_task(composite_traintask.key, raises=False)
+        composite_traintask = client.wait_task(composite_traintask.key, raise_on_failure=False)
 
         assert composite_traintask.status == Status.failed
         assert composite_traintask.error_type == substra.sdk.models.TaskErrorType.execution
@@ -409,7 +409,7 @@ def test_aggregatetask_execution_failure(factory, client, default_dataset, worke
 
     if client.backend_mode == substra.BackendType.REMOTE:
         aggregatetask = client.add_task(spec)
-        aggregatetask = client.wait_task(aggregatetask.key, raises=False)
+        aggregatetask = client.wait_task(aggregatetask.key, raise_on_failure=False)
 
         for composite_traintask_key in composite_traintask_keys:
             composite_traintask = client.get_task(composite_traintask_key)
@@ -448,7 +448,7 @@ def test_composite_traintasks_execution(factory, client, default_dataset, defaul
     )
     composite_traintask_1 = client.add_task(spec)
     # `raises = True`, will fail if task not successful
-    composite_traintask_1 = client.wait_task(composite_traintask_1.key, raises=True)
+    composite_traintask_1 = client.wait_task(composite_traintask_1.key, raise_on_failure=True)
     assert composite_traintask_1.error_type is None
     assert len(composite_traintask_1.outputs) == 2
 
@@ -461,7 +461,7 @@ def test_composite_traintasks_execution(factory, client, default_dataset, defaul
     )
     composite_traintask_2 = client.add_task(spec)
     # `raises = True`, will fail if task not successful
-    composite_traintask_2 = client.wait_task(composite_traintask_2.key, raises=True)
+    composite_traintask_2 = client.wait_task(composite_traintask_2.key, raise_on_failure=True)
     assert composite_traintask_2.error_type is None
     assert len(composite_traintask_2.outputs) == 2
 
@@ -473,7 +473,7 @@ def test_composite_traintasks_execution(factory, client, default_dataset, defaul
     )
     predicttask = client.add_task(spec)
     # `raises = True`, will fail if task not successful
-    predicttask = client.wait_task(predicttask.key, raises=True)
+    predicttask = client.wait_task(predicttask.key, raise_on_failure=True)
     assert predicttask.status == Status.done
     assert predicttask.error_type is None
 
@@ -483,7 +483,7 @@ def test_composite_traintasks_execution(factory, client, default_dataset, defaul
         worker=worker,
     )
     testtask = client.add_task(spec)
-    testtask = client.wait_task(testtask.key, raises=True)
+    testtask = client.wait_task(testtask.key, raise_on_failure=True)
     assert testtask.error_type is None
     performance = client.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
     assert performance.asset == pytest.approx(32)
@@ -538,7 +538,7 @@ def test_aggregatetask(factory, client, default_metric, default_dataset, worker)
     )
     predicttask = client.add_task(spec)
     # `raises = True`, will fail if task not successful
-    client.wait_task(predicttask.key, raises=True)
+    client.wait_task(predicttask.key, raise_on_failure=True)
 
     spec = factory.create_testtask(
         function=default_metric,
@@ -547,7 +547,7 @@ def test_aggregatetask(factory, client, default_metric, default_dataset, worker)
     )
     testtask = client.add_task(spec)
     # `raises = True`, will fail if task not successful
-    client.wait_task(testtask.key, raises=True)
+    client.wait_task(testtask.key, raise_on_failure=True)
 
 
 @pytest.mark.slow
@@ -594,7 +594,7 @@ def test_aggregatetask_chained(factory, client, default_dataset, worker):
 
     aggregatetask_2 = client.add_task(spec)
     # `raises = True`, will fail if task not successful
-    client.wait_task(aggregatetask_2.key, raises=True)
+    client.wait_task(aggregatetask_2.key, raise_on_failure=True)
     assert aggregatetask_2.error_type is None
     assert len([i for i in aggregatetask_2.inputs if i.identifier == InputIdentifiers.models]) == 1
 
@@ -643,7 +643,7 @@ def test_aggregatetask_traintask(factory, client, default_dataset, worker):
 
     traintask_2 = client.add_task(spec)
     # `raises = True`, will fail if task not successful
-    traintask_2 = client.wait_task(traintask_2.key, raises=True)
+    traintask_2 = client.wait_task(traintask_2.key, raise_on_failure=True)
 
     assert traintask_2.status == Status.done
     assert traintask_2.error_type is None
@@ -687,7 +687,7 @@ def test_composite_traintask_2_organizations_to_composite_traintask(factory, cli
     )
     composite_traintask = clients[0].add_task(spec)
     # `raises = True`, will fail if task not successful
-    clients[0].wait_task(composite_traintask.key, raises=True)
+    clients[0].wait_task(composite_traintask.key, raise_on_failure=True)
 
 
 @pytest.mark.slow
@@ -760,7 +760,7 @@ def test_aggregate_composite_traintasks(factory, network, clients, default_datas
             )
 
             t = clients[0].add_task(spec)
-            clients[0].wait_task(t.key, raises=True)
+            clients[0].wait_task(t.key, raise_on_failure=True)
             composite_traintask_keys.append(t.key)
 
         # create aggregate on its organization
@@ -770,7 +770,7 @@ def test_aggregate_composite_traintasks(factory, network, clients, default_datas
             inputs=FLTaskInputGenerator.composites_to_aggregate(composite_traintask_keys),
         )
         aggregatetask = clients[0].add_task(spec)
-        clients[0].wait_task(aggregatetask.key, raises=True)
+        clients[0].wait_task(aggregatetask.key, raise_on_failure=True)
 
         # save state of round
         previous_aggregatetask_key = aggregatetask.key
@@ -786,7 +786,7 @@ def test_aggregate_composite_traintasks(factory, network, clients, default_datas
             worker=workers[index],
         )
         predicttask = clients[0].add_task(spec)
-        clients[0].wait_task(predicttask.key, raises=True)
+        clients[0].wait_task(predicttask.key, raise_on_failure=True)
 
         spec = factory.create_testtask(
             function=metric,
@@ -794,7 +794,7 @@ def test_aggregate_composite_traintasks(factory, network, clients, default_datas
             worker=workers[index],
         )
         testtask = clients[0].add_task(spec)
-        clients[0].wait_task(testtask.key, raises=True)
+        clients[0].wait_task(testtask.key, raise_on_failure=True)
         # y_true: [20], y_pred: [52.0], result: 32.0
         performance = clients[0].get_task_output_asset(testtask.key, OutputIdentifiers.performance)
         assert performance.asset == pytest.approx(32 + index)
@@ -806,7 +806,7 @@ def test_aggregate_composite_traintasks(factory, network, clients, default_datas
         worker=workers[0],
     )
     predicttask = clients[0].add_task(spec)
-    clients[0].wait_task(predicttask.key, raises=True)
+    clients[0].wait_task(predicttask.key, raise_on_failure=True)
 
     spec = factory.create_testtask(
         function=default_metrics[0],
@@ -814,7 +814,7 @@ def test_aggregate_composite_traintasks(factory, network, clients, default_datas
         worker=workers[0],
     )
     testtask = clients[0].add_task(spec)
-    clients[0].wait_task(testtask.key, raises=True)
+    clients[0].wait_task(testtask.key, raise_on_failure=True)
     # y_true: [20], y_pred: [28.0], result: 8.0
     performance = clients[0].get_task_output_asset(testtask.key, OutputIdentifiers.performance)
     assert performance.asset == pytest.approx(8)
@@ -875,7 +875,7 @@ def test_use_data_sample_located_in_shared_path(factory, network, client, organi
 
     spec = factory.create_traintask(function=function, inputs=dataset.train_data_inputs, worker=worker)
     traintask = client.add_task(spec)
-    traintask = client.wait_task(traintask.key, raises=True)
+    traintask = client.wait_task(traintask.key, raise_on_failure=True)
     assert traintask.error_type is None
 
     # Raises an exception if the output asset have not been created
@@ -886,14 +886,14 @@ def test_use_data_sample_located_in_shared_path(factory, network, client, organi
         function=predict_function, traintask=traintask, dataset=dataset, data_samples=[data_sample_key], worker=worker
     )
     predicttask = client.add_task(spec)
-    predicttask = client.wait_task(predicttask.key, raises=True)
+    predicttask = client.wait_task(predicttask.key, raise_on_failure=True)
     assert predicttask.error_type is None
 
     spec = factory.create_testtask(
         function=default_metric, predicttask=predicttask, dataset=dataset, data_samples=[data_sample_key], worker=worker
     )
     testtask = client.add_task(spec)
-    testtask = client.wait_task(testtask.key, raises=True)
+    testtask = client.wait_task(testtask.key, raise_on_failure=True)
     assert testtask.error_type is None
     performance = client.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
     assert performance.asset == pytest.approx(2)
@@ -945,7 +945,7 @@ if __name__ == '__main__':
     function = client.add_function(spec)
     spec = factory.create_traintask(function=function, inputs=default_dataset.train_data_inputs, worker=worker)
     traintask = client.add_task(spec)
-    client.wait_task(traintask.key, raises=True)
+    client.wait_task(traintask.key, raise_on_failure=True)
 
 
 WRITE_TO_HOME_DIRECTORY_FUNCTION = f"""
@@ -996,6 +996,6 @@ def test_write_to_home_directory(factory, client, default_dataset, worker):
     function = client.add_function(spec)
     spec = factory.create_traintask(function=function, inputs=default_dataset.train_data_inputs, worker=worker)
     traintask = client.add_task(spec)
-    traintask = client.wait_task(traintask.key, raises=True)
+    traintask = client.wait_task(traintask.key, raise_on_failure=True)
 
     assert traintask.error_type is None

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -38,8 +38,7 @@ def test_tasks_execution_on_same_organization(factory, network, client, default_
 
     spec = get_traintask_spec()
     traintask = client.add_task(spec)
-    traintask = client.wait_task(traintask.key)
-    assert traintask.status == Status.done
+    traintask = client.wait_task(traintask.key, raises=True)
     assert traintask.error_type is None
     assert traintask.metadata == {"foo": "bar"}
     assert len(traintask.outputs) == 1
@@ -62,8 +61,8 @@ def test_tasks_execution_on_same_organization(factory, network, client, default_
     )
 
     predicttask = client.add_task(spec)
-    predicttask = client.wait_task(predicttask.key)
-    assert predicttask.status == Status.done
+    # `raises = True`, will fail if task not successful
+    predicttask = client.wait_task(predicttask.key, raises=True)
     assert predicttask.error_type is None
 
     spec = factory.create_testtask(
@@ -72,8 +71,8 @@ def test_tasks_execution_on_same_organization(factory, network, client, default_
         worker=worker,
     )
     testtask = client.add_task(spec)
-    testtask = client.wait_task(testtask.key)
-    assert testtask.status == Status.done
+    # `raises = True`, will fail if task not successful
+    testtask = client.wait_task(testtask.key, raises=True)
     assert testtask.error_type is None
     performance = client.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
     assert performance.asset == pytest.approx(2)
@@ -87,8 +86,8 @@ def test_tasks_execution_on_same_organization(factory, network, client, default_
         worker=worker,
     )
     traintask = client.add_task(spec)
-    traintask = client.wait_task(traintask.key)
-    assert traintask.status == Status.done
+    # `raises = True`, will fail if task not successful
+    traintask = client.wait_task(traintask.key, raises=True)
     assert testtask.error_type is None
     assert traintask.metadata == {}
 
@@ -123,9 +122,8 @@ def test_federated_learning_workflow(factory, client, default_datasets, workers)
             worker=workers[index],
         )
         traintask = client.add_task(spec)
-        traintask = client.wait_task(traintask.key)
+        traintask = client.wait_task(traintask.key, raises=True)
         out_models = client.get_task_models(traintask.key)
-        assert traintask.status == Status.done
         assert traintask.error_type is None
         assert len(traintask.outputs) == 1
         assert len(out_models) == 1
@@ -170,8 +168,8 @@ def test_tasks_execution_on_different_organizations(
         worker=workers[1],
     )
     traintask = client_1.add_task(spec)
-    traintask = client_1.wait_task(traintask.key)
-    assert traintask.status == Status.done
+    # `raises = True`, will fail if task not successful
+    traintask = client_1.wait_task(traintask.key, raises=True)
     assert traintask.error_type is None
     assert len(traintask.outputs) == 1
     # Raises an exception if the output asset have not been created
@@ -185,8 +183,8 @@ def test_tasks_execution_on_different_organizations(
         worker=workers[0],
     )
     predicttask = client_1.add_task(spec)
-    predicttask = client_1.wait_task(predicttask.key)
-    assert predicttask.status == Status.done
+    # `raises = True`, will fail if task not successful
+    predicttask = client_1.wait_task(predicttask.key, raises=True)
     assert predicttask.error_type is None
     assert predicttask.worker == client_1.organization_id
 
@@ -196,8 +194,8 @@ def test_tasks_execution_on_different_organizations(
         worker=workers[0],
     )
     testtask = client_1.add_task(spec)
-    testtask = client_1.wait_task(testtask.key)
-    assert testtask.status == Status.done
+    # `raises = True`, will fail if task not successful
+    testtask = client_1.wait_task(testtask.key, raises=True)
     assert testtask.error_type is None
     assert testtask.worker == client_1.organization_id
     performance = client_2.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
@@ -297,7 +295,8 @@ if __name__ == '__main__':
         worker=worker,
     )
     traintask = client.add_task(spec)
-    traintask = client.wait_task(traintask.key)
+    # `raises = True`, will fail if task not successful
+    traintask = client.wait_task(traintask.key, raises=True)
 
     # add predicttask
     spec = factory.create_predicttask(
@@ -306,7 +305,8 @@ if __name__ == '__main__':
         worker=worker,
     )
     predicttask = client.add_task(spec)
-    predicttask = client.wait_task(predicttask.key)
+    # `raises = True`, will fail if task not successful
+    predicttask = client.wait_task(predicttask.key, raises=True)
 
     # add metric function
     spec = factory.create_function(category=FunctionCategory.metric, py_script=custom_metric_script)
@@ -328,8 +328,8 @@ if __name__ == '__main__':
     )
 
     testtask = client.add_task(spec)
-    testtask = client.wait_task(testtask.key)
-    assert testtask.status == Status.done
+    # `raises = True`, will fail if task not successful
+    testtask = client.wait_task(testtask.key, raises=True)
     assert testtask.error_type is None
     output_1 = client.get_task_output_asset(testtask.key, identifier_1)
     output_2 = client.get_task_output_asset(testtask.key, identifier_2)
@@ -447,8 +447,8 @@ def test_composite_traintasks_execution(factory, client, default_dataset, defaul
         worker=worker,
     )
     composite_traintask_1 = client.add_task(spec)
-    composite_traintask_1 = client.wait_task(composite_traintask_1.key)
-    assert composite_traintask_1.status == Status.done
+    # `raises = True`, will fail if task not successful
+    composite_traintask_1 = client.wait_task(composite_traintask_1.key, raises=True)
     assert composite_traintask_1.error_type is None
     assert len(composite_traintask_1.outputs) == 2
 
@@ -460,8 +460,8 @@ def test_composite_traintasks_execution(factory, client, default_dataset, defaul
         worker=worker,
     )
     composite_traintask_2 = client.add_task(spec)
-    composite_traintask_2 = client.wait_task(composite_traintask_2.key)
-    assert composite_traintask_2.status == Status.done
+    # `raises = True`, will fail if task not successful
+    composite_traintask_2 = client.wait_task(composite_traintask_2.key, raises=True)
     assert composite_traintask_2.error_type is None
     assert len(composite_traintask_2.outputs) == 2
 
@@ -472,7 +472,8 @@ def test_composite_traintasks_execution(factory, client, default_dataset, defaul
         worker=worker,
     )
     predicttask = client.add_task(spec)
-    predicttask = client.wait_task(predicttask.key)
+    # `raises = True`, will fail if task not successful
+    predicttask = client.wait_task(predicttask.key, raises=True)
     assert predicttask.status == Status.done
     assert predicttask.error_type is None
 
@@ -482,8 +483,7 @@ def test_composite_traintasks_execution(factory, client, default_dataset, defaul
         worker=worker,
     )
     testtask = client.add_task(spec)
-    testtask = client.wait_task(testtask.key)
-    assert testtask.status == Status.done
+    testtask = client.wait_task(testtask.key, raises=True)
     assert testtask.error_type is None
     performance = client.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
     assert performance.asset == pytest.approx(32)
@@ -537,7 +537,8 @@ def test_aggregatetask(factory, client, default_metric, default_dataset, worker)
         worker=worker,
     )
     predicttask = client.add_task(spec)
-    predicttask = client.wait_task(predicttask.key)
+    # `raises = True`, will fail if task not successful
+    client.wait_task(predicttask.key, raises=True)
 
     spec = factory.create_testtask(
         function=default_metric,
@@ -545,7 +546,8 @@ def test_aggregatetask(factory, client, default_metric, default_dataset, worker)
         worker=worker,
     )
     testtask = client.add_task(spec)
-    testtask = client.wait_task(testtask.key)
+    # `raises = True`, will fail if task not successful
+    client.wait_task(testtask.key, raises=True)
 
 
 @pytest.mark.slow
@@ -591,8 +593,8 @@ def test_aggregatetask_chained(factory, client, default_dataset, worker):
     )
 
     aggregatetask_2 = client.add_task(spec)
-    aggregatetask_2 = client.wait_task(aggregatetask_2.key)
-    assert aggregatetask_2.status == Status.done
+    # `raises = True`, will fail if task not successful
+    client.wait_task(aggregatetask_2.key, raises=True)
     assert aggregatetask_2.error_type is None
     assert len([i for i in aggregatetask_2.inputs if i.identifier == InputIdentifiers.models]) == 1
 
@@ -640,7 +642,8 @@ def test_aggregatetask_traintask(factory, client, default_dataset, worker):
     )
 
     traintask_2 = client.add_task(spec)
-    traintask_2 = client.wait_task(traintask_2.key)
+    # `raises = True`, will fail if task not successful
+    traintask_2 = client.wait_task(traintask_2.key, raises=True)
 
     assert traintask_2.status == Status.done
     assert traintask_2.error_type is None
@@ -683,9 +686,8 @@ def test_composite_traintask_2_organizations_to_composite_traintask(factory, cli
         worker=workers[0],
     )
     composite_traintask = clients[0].add_task(spec)
-    composite_traintask = clients[0].wait_task(composite_traintask.key)
-
-    assert composite_traintask.status == Status.done
+    # `raises = True`, will fail if task not successful
+    clients[0].wait_task(composite_traintask.key, raises=True)
 
 
 @pytest.mark.slow
@@ -758,7 +760,7 @@ def test_aggregate_composite_traintasks(factory, network, clients, default_datas
             )
 
             t = clients[0].add_task(spec)
-            t = clients[0].wait_task(t.key)
+            clients[0].wait_task(t.key, raises=True)
             composite_traintask_keys.append(t.key)
 
         # create aggregate on its organization
@@ -768,7 +770,7 @@ def test_aggregate_composite_traintasks(factory, network, clients, default_datas
             inputs=FLTaskInputGenerator.composites_to_aggregate(composite_traintask_keys),
         )
         aggregatetask = clients[0].add_task(spec)
-        aggregatetask = clients[0].wait_task(aggregatetask.key)
+        clients[0].wait_task(aggregatetask.key, raises=True)
 
         # save state of round
         previous_aggregatetask_key = aggregatetask.key
@@ -784,7 +786,7 @@ def test_aggregate_composite_traintasks(factory, network, clients, default_datas
             worker=workers[index],
         )
         predicttask = clients[0].add_task(spec)
-        predicttask = clients[0].wait_task(predicttask.key)
+        clients[0].wait_task(predicttask.key, raises=True)
 
         spec = factory.create_testtask(
             function=metric,
@@ -792,7 +794,7 @@ def test_aggregate_composite_traintasks(factory, network, clients, default_datas
             worker=workers[index],
         )
         testtask = clients[0].add_task(spec)
-        testtask = clients[0].wait_task(testtask.key)
+        clients[0].wait_task(testtask.key, raises=True)
         # y_true: [20], y_pred: [52.0], result: 32.0
         performance = clients[0].get_task_output_asset(testtask.key, OutputIdentifiers.performance)
         assert performance.asset == pytest.approx(32 + index)
@@ -804,7 +806,7 @@ def test_aggregate_composite_traintasks(factory, network, clients, default_datas
         worker=workers[0],
     )
     predicttask = clients[0].add_task(spec)
-    predicttask = clients[0].wait_task(predicttask.key)
+    clients[0].wait_task(predicttask.key, raises=True)
 
     spec = factory.create_testtask(
         function=default_metrics[0],
@@ -812,7 +814,7 @@ def test_aggregate_composite_traintasks(factory, network, clients, default_datas
         worker=workers[0],
     )
     testtask = clients[0].add_task(spec)
-    testtask = clients[0].wait_task(testtask.key)
+    clients[0].wait_task(testtask.key, raises=True)
     # y_true: [20], y_pred: [28.0], result: 8.0
     performance = clients[0].get_task_output_asset(testtask.key, OutputIdentifiers.performance)
     assert performance.asset == pytest.approx(8)
@@ -873,8 +875,7 @@ def test_use_data_sample_located_in_shared_path(factory, network, client, organi
 
     spec = factory.create_traintask(function=function, inputs=dataset.train_data_inputs, worker=worker)
     traintask = client.add_task(spec)
-    traintask = client.wait_task(traintask.key)
-    assert traintask.status == Status.done
+    traintask = client.wait_task(traintask.key, raises=True)
     assert traintask.error_type is None
 
     # Raises an exception if the output asset have not been created
@@ -885,16 +886,14 @@ def test_use_data_sample_located_in_shared_path(factory, network, client, organi
         function=predict_function, traintask=traintask, dataset=dataset, data_samples=[data_sample_key], worker=worker
     )
     predicttask = client.add_task(spec)
-    predicttask = client.wait_task(predicttask.key)
-    assert predicttask.status == Status.done
+    predicttask = client.wait_task(predicttask.key, raises=True)
     assert predicttask.error_type is None
 
     spec = factory.create_testtask(
         function=default_metric, predicttask=predicttask, dataset=dataset, data_samples=[data_sample_key], worker=worker
     )
     testtask = client.add_task(spec)
-    testtask = client.wait_task(testtask.key)
-    assert testtask.status == Status.done
+    testtask = client.wait_task(testtask.key, raises=True)
     assert testtask.error_type is None
     performance = client.get_task_output_asset(testtask.key, OutputIdentifiers.performance)
     assert performance.asset == pytest.approx(2)
@@ -946,7 +945,7 @@ if __name__ == '__main__':
     function = client.add_function(spec)
     spec = factory.create_traintask(function=function, inputs=default_dataset.train_data_inputs, worker=worker)
     traintask = client.add_task(spec)
-    client.wait_task(traintask.key)
+    client.wait_task(traintask.key, raises=True)
 
 
 WRITE_TO_HOME_DIRECTORY_FUNCTION = f"""
@@ -997,7 +996,6 @@ def test_write_to_home_directory(factory, client, default_dataset, worker):
     function = client.add_function(spec)
     spec = factory.create_traintask(function=function, inputs=default_dataset.train_data_inputs, worker=worker)
     traintask = client.add_task(spec)
-    traintask = client.wait_task(traintask.key)
+    traintask = client.wait_task(traintask.key, raises=True)
 
-    assert traintask.status == Status.done
     assert traintask.error_type is None

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -436,7 +436,7 @@ def test_compute_plan_single_client_failure(factory, client, default_dataset, de
 
     # Submit compute plan and wait for it to complete
     cp_added = client.add_compute_plan(cp_spec)
-    cp = client.wait_compute_plan(cp_added.key, raises=False)
+    cp = client.wait_compute_plan(cp_added.key, raise_on_failure=False)
 
     assert cp.status == "PLAN_STATUS_FAILED"
     assert cp.end_date is not None
@@ -649,11 +649,11 @@ def test_execution_compute_plan_canceled(factory, client, default_dataset, cfg, 
     # and tasks are scheduled in the celery workers
     first_traintask = [t for t in client.list_compute_plan_tasks(cp.key) if t.rank == 0][0]
     # `raises = True`, will fail if task not successful
-    client.wait_task(first_traintask.key, raises=True)
+    client.wait_task(first_traintask.key, raise_on_failure=True)
 
     client.cancel_compute_plan(cp.key)
     # as cancel request do not directly update localrep we need to wait for the sync
-    cp = client.wait_compute_plan(cp.key, raises=False, timeout=cfg.options.organization_sync_timeout)
+    cp = client.wait_compute_plan(cp.key, raise_on_failure=False, timeout=cfg.options.organization_sync_timeout)
     assert cp.status == models.ComputePlanStatus.canceled
     assert cp.end_date is not None
     assert cp.duration is not None

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -648,8 +648,8 @@ def test_execution_compute_plan_canceled(factory, client, default_dataset, cfg, 
     # wait the first traintask to be executed to ensure that the compute plan is launched
     # and tasks are scheduled in the celery workers
     first_traintask = [t for t in client.list_compute_plan_tasks(cp.key) if t.rank == 0][0]
-    first_traintask = client.wait_task(first_traintask.key)
-    assert first_traintask.status == models.Status.done
+    # `raises = True`, will fail if task not successful
+    client.wait_task(first_traintask.key, raises=True)
 
     client.cancel_compute_plan(cp.key)
     # as cancel request do not directly update localrep we need to wait for the sync

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -170,7 +170,7 @@ def test_permissions(permissions_1, permissions_2, expected_permissions, factory
     )
     channel.wait_for_asset_synchronized(function_2)
     traintask = client_1.add_task(spec)
-    client_1.wait_task(traintask.key, raises=True)
+    client_1.wait_task(traintask.key, raise_on_failure=True)
 
     # check the compute task executed on the correct worker
     # Raises an exception if the output asset have not been created
@@ -268,7 +268,7 @@ def test_permissions_model_process(
         worker=workers[0],
     )
     traintask_1 = client_1.add_task(spec)
-    traintask_1 = client_1.wait_task(traintask_1.key, raises=True)
+    traintask_1 = client_1.wait_task(traintask_1.key, raise_on_failure=True)
 
     assert not traintask_1.outputs[OutputIdentifiers.model].permissions.process.public
     assert set(traintask_1.outputs[OutputIdentifiers.model].permissions.process.authorized_ids) == set(
@@ -284,7 +284,7 @@ def test_permissions_model_process(
     with expectation:
         traintask_2 = client_2.add_task(spec)
 
-        client_2.wait_task(traintask_2.key, raises=True)
+        client_2.wait_task(traintask_2.key, raise_on_failure=True)
 
 
 @pytest.mark.remote_only  # no check on permissions with the local backend
@@ -344,7 +344,7 @@ def test_merge_permissions_denied_process(factory, clients, channel, workers):
         # add traintask from node 2
         spec = factory.create_traintask(function=function_2, inputs=dataset_1.train_data_inputs, worker=workers[0])
         traintask_2 = client_2.add_task(spec)
-        traintask_2 = client_2.wait_task(traintask_2.key, raises=True)
+        traintask_2 = client_2.wait_task(traintask_2.key, raise_on_failure=True)
         channel.wait_for_asset_synchronized(traintask_2)  # used by client_3
 
         # failed to add predicttask from organization 3
@@ -398,7 +398,7 @@ def test_permissions_denied_head_model_process(factory, client_1, client_2, chan
     )
 
     composite_traintask_1 = client_1.add_task(spec)
-    composite_traintask_1 = client_1.wait_task(composite_traintask_1.key, raises=True)
+    composite_traintask_1 = client_1.wait_task(composite_traintask_1.key, raise_on_failure=True)
     channel.wait_for_asset_synchronized(composite_traintask_1)  # used by client_2
 
     spec = factory.create_composite_traintask(

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -170,7 +170,7 @@ def test_permissions(permissions_1, permissions_2, expected_permissions, factory
     )
     channel.wait_for_asset_synchronized(function_2)
     traintask = client_1.add_task(spec)
-    traintask = client_1.wait_task(traintask.key)
+    client_1.wait_task(traintask.key, raises=True)
 
     # check the compute task executed on the correct worker
     # Raises an exception if the output asset have not been created
@@ -268,7 +268,7 @@ def test_permissions_model_process(
         worker=workers[0],
     )
     traintask_1 = client_1.add_task(spec)
-    traintask_1 = client_1.wait_task(traintask_1.key)
+    traintask_1 = client_1.wait_task(traintask_1.key, raises=True)
 
     assert not traintask_1.outputs[OutputIdentifiers.model].permissions.process.public
     assert set(traintask_1.outputs[OutputIdentifiers.model].permissions.process.authorized_ids) == set(
@@ -284,7 +284,7 @@ def test_permissions_model_process(
     with expectation:
         traintask_2 = client_2.add_task(spec)
 
-        client_2.wait_task(traintask_2.key)
+        client_2.wait_task(traintask_2.key, raises=True)
 
 
 @pytest.mark.remote_only  # no check on permissions with the local backend
@@ -344,7 +344,7 @@ def test_merge_permissions_denied_process(factory, clients, channel, workers):
         # add traintask from node 2
         spec = factory.create_traintask(function=function_2, inputs=dataset_1.train_data_inputs, worker=workers[0])
         traintask_2 = client_2.add_task(spec)
-        traintask_2 = client_2.wait_task(traintask_2.key)
+        traintask_2 = client_2.wait_task(traintask_2.key, raises=True)
         channel.wait_for_asset_synchronized(traintask_2)  # used by client_3
 
         # failed to add predicttask from organization 3
@@ -398,7 +398,7 @@ def test_permissions_denied_head_model_process(factory, client_1, client_2, chan
     )
 
     composite_traintask_1 = client_1.add_task(spec)
-    composite_traintask_1 = client_1.wait_task(composite_traintask_1.key)
+    composite_traintask_1 = client_1.wait_task(composite_traintask_1.key, raises=True)
     channel.wait_for_asset_synchronized(composite_traintask_1)  # used by client_2
 
     spec = factory.create_composite_traintask(

--- a/tests/test_synchronized.py
+++ b/tests/test_synchronized.py
@@ -83,7 +83,7 @@ def test_synchronized_traintask(clients, factory, channel, current_client, worke
     # create traintask
     spec = factory.create_traintask(function=function, inputs=dataset.train_data_inputs, worker=worker)
     traintask = current_client.add_task(spec)
-    traintask = current_client.wait_task(traintask.key, raises=True)
+    traintask = current_client.wait_task(traintask.key, raise_on_failure=True)
     channel.wait_for_asset_synchronized(traintask)
 
 

--- a/tests/test_synchronized.py
+++ b/tests/test_synchronized.py
@@ -83,7 +83,7 @@ def test_synchronized_traintask(clients, factory, channel, current_client, worke
     # create traintask
     spec = factory.create_traintask(function=function, inputs=dataset.train_data_inputs, worker=worker)
     traintask = current_client.add_task(spec)
-    traintask = current_client.wait_task(traintask.key)
+    traintask = current_client.wait_task(traintask.key, raises=True)
     channel.wait_for_asset_synchronized(traintask)
 
 


### PR DESCRIPTION
## Related issue

- https://github.com/Substra/substra/pull/368
- https://github.com/Substra/substrafl/pull/147
- https://github.com/Substra/substra-tests/pull/263
- https://github.com/Substra/substra-documentation/pull/327

## Summary

Centralize `wait_task` and `wait_compute_plan`, and re-use the implementation added in `substra` through the other components.

## Notes

Fixes FL-1052

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
