### PR TITLE
feat!: add new compute tasks status linked to function status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nightly is now done on `owkin/substra-ci` repository ([#304](https://github.com/Substra/substra-tests/pull/304))
 - Parallelism in SDK tests in deactivated until we fix the parallel compute plans issues ([#306](https://github.com/Substra/substra-tests/pull/306))
 - A bunch of SDK tests are skipped due to regressions following the decoupled builder merge ([#306](https://github.com/Substra/substra-tests/pull/306))
+- BREAKING: replace `todo_count` and `waiting_cont` by the new counts following the new statuses in the backend ([#319](https://github.com/Substra/substra-tests/pull/319))
 
 ## [0.47.0] - 2023-10-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nightly is now done on `owkin/substra-ci` repository ([#304](https://github.com/Substra/substra-tests/pull/304))
 - Parallelism in SDK tests in deactivated until we fix the parallel compute plans issues ([#306](https://github.com/Substra/substra-tests/pull/306))
 - A bunch of SDK tests are skipped due to regressions following the decoupled builder merge ([#306](https://github.com/Substra/substra-tests/pull/306))
-- BREAKING: replace `todo_count` and `waiting_cont` by the new counts following the new statuses in the backend ([#319](https://github.com/Substra/substra-tests/pull/319))
+- BREAKING: replace `todo_count` and `waiting_count` by the new counts following the new statuses in the backend ([#319](https://github.com/Substra/substra-tests/pull/319))
 
 ## [0.47.0] - 2023-10-18
 

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -88,7 +88,16 @@ def test_compute_plan_simple(
     assert cp.tag == "foo"
     assert cp.metadata == {"foo": "bar"}
     assert cp.task_count == cp.done_count == 5
-    assert cp.todo_count == cp.waiting_count == cp.doing_count == cp.canceled_count == cp.failed_count == 0
+    assert (
+        cp.waiting_parent_tasks_count
+        == cp.waiting_executor_slot_count
+        == cp.waiting_builder_slot_count
+        == cp.building_count
+        == cp.doing_count
+        == cp.canceled_count
+        == cp.failed_count
+        == 0
+    )
     assert cp.end_date is not None
     assert cp.duration is not None
 


### PR DESCRIPTION
# Companion PR

- https://github.com/Substra/orchestrator/pull/366
- https://github.com/Substra/substra-backend/pull/823
- https://github.com/Substra/substra/pull/397
- https://github.com/Substra/substra-frontend/pull/297
- https://github.com/Substra/substra-documentation/pull/390

Fixes FL-1397


Tests are failing because the changes on `substra` are not on `main` yet