### PR TITLE
chore: bump Pytorch version to 2.2.1 in tests

### DIFF
--- a/changes/363.added
+++ b/changes/363.added
@@ -1,0 +1,1 @@
+Python 3.12 support.

--- a/changes/369.fixed
+++ b/changes/369.fixed
@@ -1,0 +1,1 @@
+Bump pytorch version to 2.2.1 in tests.

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -17,7 +17,7 @@ FROM python:3.12-slim
 RUN apt-get update -y && apt-get install -y git
 RUN python3 -m pip install -U pip
 RUN python3 -m pip install git+https://github.com/Substra/substra-tools.git@{substratools_git_ref}
-RUN python3 -m pip install --no-cache-dir torch==2.0.1
+RUN python3 -m pip install --no-cache-dir torch==2.2.0
 COPY function.py .
 
 ENTRYPOINT ["python3", "function.py"]

--- a/tests/workflows/mnist-fedavg/test_workflow.py
+++ b/tests/workflows/mnist-fedavg/test_workflow.py
@@ -67,7 +67,7 @@ def function_dockerfile(cfg: PytestConfig) -> str:
         "WORKDIR /sandbox \n"
         f"COPY function.py .\n"
         "RUN python3 -m pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu \
-            numpy==1.24.3 scikit-learn==1.3.1 torch==2.0.1\n"
+            numpy==1.24.3 scikit-learn==1.3.1 torch==2.2.1\n"
         f'ENTRYPOINT ["python3", "function.py", "--function-name", "{{method_name}}"]\n'
     )
 


### PR DESCRIPTION
Fixes CI following Python 3.12 support.